### PR TITLE
Add email_id to SendMagicByEmailResponse

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -120,6 +120,7 @@ declare module 'stytch' {
 
     interface SendMagicLinkByEmailResponse extends BaseResponse {
         user_id: string;
+        email_id: string;
     }
 
     interface LoginOrCreateRequest {


### PR DESCRIPTION
Updating `/v1/magic_links/send_by_email` to include `email_id` field in response