### PR TITLE
Fix version number in package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "stytch",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
I forgot to run `npm install` to update the lockfile's version number in #28.  This should happen before publishing v1.2.4 to NPM according to our publishing instructions.
