### PR TITLE
Fix version number in package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "stytch",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
I forgot to run `npm install` to update the lockfile's version number in #27.  This should happen before publishing v2.0.1 to NPM according to our publishing instructions.
