### PR TITLE
fix: Correct backward-compatibile method aliases

### DIFF
--- a/dist/client.js
+++ b/dist/client.js
@@ -26,35 +26,6 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 const DEFAULT_TIMEOUT = 10 * 60 * 1000; // Ten minutes
 
 class Client {
-  /** @deprecated since version 3.0. Will be deleted in version 4.0.  Use users.create instead. */
-
-  /** @deprecated since version 3.0. Will be deleted in version 4.0.  Use users.get instead. */
-
-  /** @deprecated since version 3.0. Will be deleted in version 4.0.  Use users.update instead. */
-
-  /** @deprecated since version 3.0. Will be deleted in version 4.0.  Use users.delete instead. */
-
-  /** @deprecated since version 3.0. Will be deleted in version 4.0.  Use users.deleteEmail instead. */
-
-  /** @deprecated since version 3.0. Will be deleted in version 4.0.  Use users.deletePhoneNumber instead. */
-
-  /** @deprecated since version 3.0. Will be deleted in version 4.0.  Use users.getPending instead. */
-
-  /** @deprecated since version 3.0. Will be deleted in version 4.0.  Use magicLinks.email.send instead. */
-
-  /** @deprecated since version 3.0. Will be deleted in version 4.0.  Use magicLinks.email.loginOrCreate instead. */
-
-  /** @deprecated since version 3.0. Will be deleted in version 4.0.  Use magicLinks.email.invite instead. */
-
-  /** @deprecated since version 3.0. Will be deleted in version 4.0.  Use magicLinks.email.revokeInvite instead. */
-
-  /** @deprecated since version 3.0. Will be deleted in version 4.0.  Use magicLinks.authenticate instead. */
-
-  /** @deprecated since version 3.0. Will be deleted in version 4.0.  Use magicLinks.otps.sms.send instead. */
-
-  /** @deprecated since version 3.0. Will be deleted in version 4.0.  Use magicLinks.otps.sms.loginOrCreate instead. */
-
-  /** @deprecated since version 3.0. Will be deleted in version 4.0.  Use magicLinks.otps.authenticate instead. */
   constructor(config) {
     if (typeof config != "object") {
       throw new Error("Unexpected config type. Refer to https://github.com/stytchauth/stytch-node for how to use the Node client library.");
@@ -89,23 +60,97 @@ class Client {
     });
     this.users = new _users.Users(this.client);
     this.magicLinks = new _magic_links.MagicLinks(this.client);
-    this.otps = new _otps.OTPs(this.client); // TODO(v4): Remove these deprecated methods.
+    this.otps = new _otps.OTPs(this.client);
+  }
+  /** @deprecated since version 3.0. Will be deleted in version 4.0.  Use users.create instead. */
 
-    this.createUser = this.users.create;
-    this.getUser = this.users.get;
-    this.updateUser = this.users.update;
-    this.deleteUser = this.users.delete;
-    this.deleteUserEmail = this.users.deleteEmail;
-    this.deleteUserPhoneNumber = this.users.deletePhoneNumber;
-    this.getPendingUsers = this.users.getPending;
-    this.sendMagicLinkByEmail = this.magicLinks.email.send;
-    this.loginOrCreate = this.magicLinks.email.loginOrCreate;
-    this.inviteByEmail = this.magicLinks.email.invite;
-    this.revokePendingInvite = this.magicLinks.email.revokeInvite;
-    this.authenticateMagicLink = this.magicLinks.authenticate;
-    this.sendOTPBySMS = this.otps.sms.send;
-    this.loginOrCreateUserBySMS = this.otps.sms.loginOrCreate;
-    this.authenticateOTP = this.otps.authenticate;
+
+  createUser(request) {
+    return this.users.create(request);
+  }
+  /** @deprecated since version 3.0. Will be deleted in version 4.0.  Use users.get instead. */
+
+
+  getUser(userID) {
+    return this.users.get(userID);
+  }
+  /** @deprecated since version 3.0. Will be deleted in version 4.0.  Use users.update instead. */
+
+
+  updateUser(userID, request) {
+    return this.users.update(userID, request);
+  }
+  /** @deprecated since version 3.0. Will be deleted in version 4.0.  Use users.delete instead. */
+
+
+  deleteUser(userID) {
+    return this.users.delete(userID);
+  }
+  /** @deprecated since version 3.0. Will be deleted in version 4.0.  Use users.deleteEmail instead. */
+
+
+  deleteUserEmail(emailID) {
+    return this.users.deleteEmail(emailID);
+  }
+  /** @deprecated since version 3.0. Will be deleted in version 4.0.  Use users.deletePhoneNumber instead. */
+
+
+  deleteUserPhoneNumber(phoneID) {
+    return this.users.deletePhoneNumber(phoneID);
+  }
+  /** @deprecated since version 3.0. Will be deleted in version 4.0.  Use users.getPending instead. */
+
+
+  getPendingUsers(request) {
+    return this.users.getPending(request);
+  }
+  /** @deprecated since version 3.0. Will be deleted in version 4.0.  Use magicLinks.email.send instead. */
+
+
+  sendMagicLinkByEmail(data) {
+    return this.magicLinks.email.send(data);
+  }
+  /** @deprecated since version 3.0. Will be deleted in version 4.0.  Use magicLinks.email.loginOrCreate instead. */
+
+
+  loginOrCreate(data) {
+    return this.magicLinks.email.loginOrCreate(data);
+  }
+  /** @deprecated since version 3.0. Will be deleted in version 4.0.  Use magicLinks.email.invite instead. */
+
+
+  inviteByEmail(data) {
+    return this.magicLinks.email.invite(data);
+  }
+  /** @deprecated since version 3.0. Will be deleted in version 4.0.  Use magicLinks.email.revokeInvite instead. */
+
+
+  revokePendingInvite(data) {
+    return this.magicLinks.email.revokeInvite(data);
+  }
+  /** @deprecated since version 3.0. Will be deleted in version 4.0.  Use magicLinks.authenticate instead. */
+
+
+  authenticateMagicLink(token, data) {
+    return this.magicLinks.authenticate(token, data);
+  }
+  /** @deprecated since version 3.0. Will be deleted in version 4.0.  Use otps.sms.send instead. */
+
+
+  sendOTPBySMS(data) {
+    return this.otps.sms.send(data);
+  }
+  /** @deprecated since version 3.0. Will be deleted in version 4.0.  Use otps.sms.loginOrCreate instead. */
+
+
+  loginOrCreateUserBySMS(data) {
+    return this.otps.sms.loginOrCreate(data);
+  }
+  /** @deprecated since version 3.0. Will be deleted in version 4.0.  Use otps.authenticate instead. */
+
+
+  authenticateOTP(data) {
+    return this.otps.authenticate(data);
   }
 
 }

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -6,6 +6,9 @@ import { MagicLinks } from "./magic_links";
 import { OTPs } from "./otps";
 
 import type { AxiosInstance } from "axios";
+import type * as users from "./users";
+import type * as magicLinks from "./magic_links";
+import type * as otps from "./otps";
 
 const DEFAULT_TIMEOUT = 10 * 60 * 1000; // Ten minutes
 
@@ -20,37 +23,6 @@ export class Client {
   users: Users;
   magicLinks: MagicLinks;
   otps: OTPs;
-
-  /** @deprecated since version 3.0. Will be deleted in version 4.0.  Use users.create instead. */
-  createUser;
-  /** @deprecated since version 3.0. Will be deleted in version 4.0.  Use users.get instead. */
-  getUser;
-  /** @deprecated since version 3.0. Will be deleted in version 4.0.  Use users.update instead. */
-  updateUser;
-  /** @deprecated since version 3.0. Will be deleted in version 4.0.  Use users.delete instead. */
-  deleteUser;
-  /** @deprecated since version 3.0. Will be deleted in version 4.0.  Use users.deleteEmail instead. */
-  deleteUserEmail;
-  /** @deprecated since version 3.0. Will be deleted in version 4.0.  Use users.deletePhoneNumber instead. */
-  deleteUserPhoneNumber;
-  /** @deprecated since version 3.0. Will be deleted in version 4.0.  Use users.getPending instead. */
-  getPendingUsers;
-  /** @deprecated since version 3.0. Will be deleted in version 4.0.  Use magicLinks.email.send instead. */
-  sendMagicLinkByEmail;
-  /** @deprecated since version 3.0. Will be deleted in version 4.0.  Use magicLinks.email.loginOrCreate instead. */
-  loginOrCreate;
-  /** @deprecated since version 3.0. Will be deleted in version 4.0.  Use magicLinks.email.invite instead. */
-  inviteByEmail;
-  /** @deprecated since version 3.0. Will be deleted in version 4.0.  Use magicLinks.email.revokeInvite instead. */
-  revokePendingInvite;
-  /** @deprecated since version 3.0. Will be deleted in version 4.0.  Use magicLinks.authenticate instead. */
-  authenticateMagicLink;
-  /** @deprecated since version 3.0. Will be deleted in version 4.0.  Use magicLinks.otps.sms.send instead. */
-  sendOTPBySMS;
-  /** @deprecated since version 3.0. Will be deleted in version 4.0.  Use magicLinks.otps.sms.loginOrCreate instead. */
-  loginOrCreateUserBySMS;
-  /** @deprecated since version 3.0. Will be deleted in version 4.0.  Use magicLinks.otps.authenticate instead. */
-  authenticateOTP;
 
   private client: AxiosInstance;
 
@@ -93,22 +65,104 @@ export class Client {
     this.users = new Users(this.client);
     this.magicLinks = new MagicLinks(this.client);
     this.otps = new OTPs(this.client);
+  }
 
-    // TODO(v4): Remove these deprecated methods.
-    this.createUser = this.users.create;
-    this.getUser = this.users.get;
-    this.updateUser = this.users.update;
-    this.deleteUser = this.users.delete;
-    this.deleteUserEmail = this.users.deleteEmail;
-    this.deleteUserPhoneNumber = this.users.deletePhoneNumber;
-    this.getPendingUsers = this.users.getPending;
-    this.sendMagicLinkByEmail = this.magicLinks.email.send;
-    this.loginOrCreate = this.magicLinks.email.loginOrCreate;
-    this.inviteByEmail = this.magicLinks.email.invite;
-    this.revokePendingInvite = this.magicLinks.email.revokeInvite;
-    this.authenticateMagicLink = this.magicLinks.authenticate;
-    this.sendOTPBySMS = this.otps.sms.send;
-    this.loginOrCreateUserBySMS = this.otps.sms.loginOrCreate;
-    this.authenticateOTP = this.otps.authenticate;
+  /** @deprecated since version 3.0. Will be deleted in version 4.0.  Use users.create instead. */
+  createUser(request: users.CreateRequest): Promise<users.CreateResponse> {
+    return this.users.create(request);
+  }
+
+  /** @deprecated since version 3.0. Will be deleted in version 4.0.  Use users.get instead. */
+  getUser(userID: users.UserID): Promise<users.GetResponse> {
+    return this.users.get(userID);
+  }
+
+  /** @deprecated since version 3.0. Will be deleted in version 4.0.  Use users.update instead. */
+  updateUser(
+    userID: users.UserID,
+    request: users.UpdateRequest
+  ): Promise<users.UpdateResponse> {
+    return this.users.update(userID, request);
+  }
+
+  /** @deprecated since version 3.0. Will be deleted in version 4.0.  Use users.delete instead. */
+  deleteUser(userID: users.UserID): Promise<users.DeleteResponse> {
+    return this.users.delete(userID);
+  }
+
+  /** @deprecated since version 3.0. Will be deleted in version 4.0.  Use users.deleteEmail instead. */
+  deleteUserEmail(emailID: string): Promise<users.DeleteEmailResponse> {
+    return this.users.deleteEmail(emailID);
+  }
+
+  /** @deprecated since version 3.0. Will be deleted in version 4.0.  Use users.deletePhoneNumber instead. */
+  deleteUserPhoneNumber(
+    phoneID: string
+  ): Promise<users.DeletePhoneNumberResponse> {
+    return this.users.deletePhoneNumber(phoneID);
+  }
+
+  /** @deprecated since version 3.0. Will be deleted in version 4.0.  Use users.getPending instead. */
+  getPendingUsers(
+    request?: users.GetPendingRequest
+  ): Promise<users.GetPendingResponse> {
+    return this.users.getPending(request);
+  }
+
+  /** @deprecated since version 3.0. Will be deleted in version 4.0.  Use magicLinks.email.send instead. */
+  sendMagicLinkByEmail(
+    data: magicLinks.SendByEmailRequest
+  ): Promise<magicLinks.SendByEmailResponse> {
+    return this.magicLinks.email.send(data);
+  }
+
+  /** @deprecated since version 3.0. Will be deleted in version 4.0.  Use magicLinks.email.loginOrCreate instead. */
+  loginOrCreate(
+    data: magicLinks.LoginOrCreateByEmailRequest
+  ): Promise<magicLinks.LoginOrCreateByEmailResponse> {
+    return this.magicLinks.email.loginOrCreate(data);
+  }
+
+  /** @deprecated since version 3.0. Will be deleted in version 4.0.  Use magicLinks.email.invite instead. */
+  inviteByEmail(
+    data: magicLinks.InviteByEmailRequest
+  ): Promise<magicLinks.InviteByEmailResponse> {
+    return this.magicLinks.email.invite(data);
+  }
+
+  /** @deprecated since version 3.0. Will be deleted in version 4.0.  Use magicLinks.email.revokeInvite instead. */
+  revokePendingInvite(
+    data: magicLinks.RevokePendingInviteByEmailRequest
+  ): Promise<magicLinks.RevokePendingInviteByEmailResponse> {
+    return this.magicLinks.email.revokeInvite(data);
+  }
+
+  /** @deprecated since version 3.0. Will be deleted in version 4.0.  Use magicLinks.authenticate instead. */
+  authenticateMagicLink(
+    token: string,
+    data?: magicLinks.AuthenticateRequest
+  ): Promise<magicLinks.AuthenticateResponse> {
+    return this.magicLinks.authenticate(token, data);
+  }
+
+  /** @deprecated since version 3.0. Will be deleted in version 4.0.  Use otps.sms.send instead. */
+  sendOTPBySMS(
+    data: otps.SendOTPBySMSRequest
+  ): Promise<otps.SendOTPBySMSResponse> {
+    return this.otps.sms.send(data);
+  }
+
+  /** @deprecated since version 3.0. Will be deleted in version 4.0.  Use otps.sms.loginOrCreate instead. */
+  loginOrCreateUserBySMS(
+    data: otps.LoginOrCreateUserBySMSRequest
+  ): Promise<otps.LoginOrCreateUserBySMSResponse> {
+    return this.otps.sms.loginOrCreate(data);
+  }
+
+  /** @deprecated since version 3.0. Will be deleted in version 4.0.  Use otps.authenticate instead. */
+  authenticateOTP(
+    data: otps.AuthenticateRequest
+  ): Promise<otps.AuthenticateResponse> {
+    return this.otps.authenticate(data);
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stytch",
-  "version": "3.0.0-beta.1",
+  "version": "3.0.0-beta.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "stytch",
-      "version": "3.0.0-beta.1",
+      "version": "3.0.0-beta.2",
       "license": "MIT",
       "dependencies": {
         "axios": "^0.21.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stytch",
-  "version": "3.0.0-beta.2",
+  "version": "3.0.0-beta.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "stytch",
-      "version": "3.0.0-beta.2",
+      "version": "3.0.0-beta.3",
       "license": "MIT",
       "dependencies": {
         "axios": "^0.21.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stytch",
-  "version": "3.0.0-beta.1",
+  "version": "3.0.0-beta.2",
   "description": "A wrapper for the Stytch API",
   "types": "./types/lib/index.d.ts",
   "main": "./dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stytch",
-  "version": "3.0.0-beta.2",
+  "version": "3.0.0-beta.3",
   "description": "A wrapper for the Stytch API",
   "types": "./types/lib/index.d.ts",
   "main": "./dist/index.js",

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -40,29 +40,27 @@ describe("config errors", () => {
 
 describe("backward compatibility", () => {
   // TODO(v4): Remove these deprecated methods.
-  test("v2.0 top-level client methods", () => {
+  test("v2.0 top-level client methods still exist", () => {
     const client = new stytch.Client({
       project_id: "project-test-00000000-0000-4000-8000-000000000000",
       secret: "secret-test-11111111-1111-4111-8111-111111111111",
       env: stytch.envs.test,
     });
 
-    expect(client.createUser).toBe(client.users.create);
-    expect(client.getUser).toBe(client.users.get);
-    expect(client.updateUser).toBe(client.users.update);
-    expect(client.deleteUser).toBe(client.users.delete);
-    expect(client.deleteUserEmail).toBe(client.users.deleteEmail);
-    expect(client.deleteUserPhoneNumber).toBe(client.users.deletePhoneNumber);
-    expect(client.getPendingUsers).toBe(client.users.getPending);
-    expect(client.sendMagicLinkByEmail).toBe(client.magicLinks.email.send);
-    expect(client.loginOrCreate).toBe(client.magicLinks.email.loginOrCreate);
-    expect(client.inviteByEmail).toBe(client.magicLinks.email.invite);
-    expect(client.revokePendingInvite).toBe(
-      client.magicLinks.email.revokeInvite
-    );
-    expect(client.authenticateMagicLink).toBe(client.magicLinks.authenticate);
-    expect(client.sendOTPBySMS).toBe(client.otps.sms.send);
-    expect(client.loginOrCreateUserBySMS).toBe(client.otps.sms.loginOrCreate);
-    expect(client.authenticateOTP).toBe(client.otps.authenticate);
+    expect(client.createUser).toBeTruthy();
+    expect(client.getUser).toBeTruthy();
+    expect(client.updateUser).toBeTruthy();
+    expect(client.deleteUser).toBeTruthy();
+    expect(client.deleteUserEmail).toBeTruthy();
+    expect(client.deleteUserPhoneNumber).toBeTruthy();
+    expect(client.getPendingUsers).toBeTruthy();
+    expect(client.sendMagicLinkByEmail).toBeTruthy();
+    expect(client.loginOrCreate).toBeTruthy();
+    expect(client.inviteByEmail).toBeTruthy();
+    expect(client.revokePendingInvite).toBeTruthy();
+    expect(client.authenticateMagicLink).toBeTruthy();
+    expect(client.sendOTPBySMS).toBeTruthy();
+    expect(client.loginOrCreateUserBySMS).toBeTruthy();
+    expect(client.authenticateOTP).toBeTruthy();
   });
 });

--- a/test/sandbox.test.ts
+++ b/test/sandbox.test.ts
@@ -132,5 +132,20 @@ describeIf(
           });
       });
     });
+
+    // TODO(v4): Remove these deprecated methods
+    describe("sendMagicLinkByEmail", () => {
+      test("success", () => {
+        return client
+          .sendMagicLinkByEmail({
+            email: "sandbox@stytch.com",
+            login_magic_link_url: "http://localhost:8000/login",
+            signup_magic_link_url: "http://localhost:8000/signup",
+          })
+          .then((res) => {
+            expect(res.status_code).toEqual(200);
+          });
+      });
+    });
   }
 );

--- a/types/lib/client.d.ts
+++ b/types/lib/client.d.ts
@@ -1,6 +1,9 @@
 import { Users } from "./users";
 import { MagicLinks } from "./magic_links";
 import { OTPs } from "./otps";
+import type * as users from "./users";
+import type * as magicLinks from "./magic_links";
+import type * as otps from "./otps";
 interface Config {
     project_id: string;
     secret: string;
@@ -11,37 +14,37 @@ export declare class Client {
     users: Users;
     magicLinks: MagicLinks;
     otps: OTPs;
-    /** @deprecated since version 3.0. Will be deleted in version 4.0.  Use users.create instead. */
-    createUser: (request: import("./users").CreateRequest) => Promise<import("./users").CreateResponse>;
-    /** @deprecated since version 3.0. Will be deleted in version 4.0.  Use users.get instead. */
-    getUser: (userID: string) => Promise<import("./users").GetResponse>;
-    /** @deprecated since version 3.0. Will be deleted in version 4.0.  Use users.update instead. */
-    updateUser: (userID: string, request: import("./users").UpdateRequest) => Promise<import("./users").UpdateResponse>;
-    /** @deprecated since version 3.0. Will be deleted in version 4.0.  Use users.delete instead. */
-    deleteUser: (userID: string) => Promise<import("./users").DeleteResponse>;
-    /** @deprecated since version 3.0. Will be deleted in version 4.0.  Use users.deleteEmail instead. */
-    deleteUserEmail: (emailID: string) => Promise<import("./users").DeleteEmailResponse>;
-    /** @deprecated since version 3.0. Will be deleted in version 4.0.  Use users.deletePhoneNumber instead. */
-    deleteUserPhoneNumber: (phoneID: string) => Promise<import("./users").DeletePhoneNumberResponse>;
-    /** @deprecated since version 3.0. Will be deleted in version 4.0.  Use users.getPending instead. */
-    getPendingUsers: (request?: import("./users").GetPendingRequest | undefined) => Promise<import("./users").GetPendingResponse>;
-    /** @deprecated since version 3.0. Will be deleted in version 4.0.  Use magicLinks.email.send instead. */
-    sendMagicLinkByEmail: (data: import("./magic_links").SendByEmailRequest) => Promise<import("./magic_links").SendByEmailResponse>;
-    /** @deprecated since version 3.0. Will be deleted in version 4.0.  Use magicLinks.email.loginOrCreate instead. */
-    loginOrCreate: (data: import("./magic_links").LoginOrCreateByEmailRequest) => Promise<import("./magic_links").LoginOrCreateByEmailResponse>;
-    /** @deprecated since version 3.0. Will be deleted in version 4.0.  Use magicLinks.email.invite instead. */
-    inviteByEmail: (data: import("./magic_links").InviteByEmailRequest) => Promise<import("./magic_links").InviteByEmailResponse>;
-    /** @deprecated since version 3.0. Will be deleted in version 4.0.  Use magicLinks.email.revokeInvite instead. */
-    revokePendingInvite: (data: import("./magic_links").RevokePendingInviteByEmailRequest) => Promise<import("./magic_links").RevokePendingInviteByEmailResponse>;
-    /** @deprecated since version 3.0. Will be deleted in version 4.0.  Use magicLinks.authenticate instead. */
-    authenticateMagicLink: (token: string, data?: import("./magic_links").AuthenticateRequest | undefined) => Promise<import("./magic_links").AuthenticateResponse>;
-    /** @deprecated since version 3.0. Will be deleted in version 4.0.  Use magicLinks.otps.sms.send instead. */
-    sendOTPBySMS: (data: import("./otps").SendOTPBySMSRequest) => Promise<import("./otps").SendOTPBySMSResponse>;
-    /** @deprecated since version 3.0. Will be deleted in version 4.0.  Use magicLinks.otps.sms.loginOrCreate instead. */
-    loginOrCreateUserBySMS: (data: import("./otps").LoginOrCreateUserBySMSRequest) => Promise<import("./otps").LoginOrCreateUserBySMSResponse>;
-    /** @deprecated since version 3.0. Will be deleted in version 4.0.  Use magicLinks.otps.authenticate instead. */
-    authenticateOTP: (data: import("./otps").AuthenticateRequest) => Promise<import("./otps").AuthenticateResponse>;
     private client;
     constructor(config: Config);
+    /** @deprecated since version 3.0. Will be deleted in version 4.0.  Use users.create instead. */
+    createUser(request: users.CreateRequest): Promise<users.CreateResponse>;
+    /** @deprecated since version 3.0. Will be deleted in version 4.0.  Use users.get instead. */
+    getUser(userID: users.UserID): Promise<users.GetResponse>;
+    /** @deprecated since version 3.0. Will be deleted in version 4.0.  Use users.update instead. */
+    updateUser(userID: users.UserID, request: users.UpdateRequest): Promise<users.UpdateResponse>;
+    /** @deprecated since version 3.0. Will be deleted in version 4.0.  Use users.delete instead. */
+    deleteUser(userID: users.UserID): Promise<users.DeleteResponse>;
+    /** @deprecated since version 3.0. Will be deleted in version 4.0.  Use users.deleteEmail instead. */
+    deleteUserEmail(emailID: string): Promise<users.DeleteEmailResponse>;
+    /** @deprecated since version 3.0. Will be deleted in version 4.0.  Use users.deletePhoneNumber instead. */
+    deleteUserPhoneNumber(phoneID: string): Promise<users.DeletePhoneNumberResponse>;
+    /** @deprecated since version 3.0. Will be deleted in version 4.0.  Use users.getPending instead. */
+    getPendingUsers(request?: users.GetPendingRequest): Promise<users.GetPendingResponse>;
+    /** @deprecated since version 3.0. Will be deleted in version 4.0.  Use magicLinks.email.send instead. */
+    sendMagicLinkByEmail(data: magicLinks.SendByEmailRequest): Promise<magicLinks.SendByEmailResponse>;
+    /** @deprecated since version 3.0. Will be deleted in version 4.0.  Use magicLinks.email.loginOrCreate instead. */
+    loginOrCreate(data: magicLinks.LoginOrCreateByEmailRequest): Promise<magicLinks.LoginOrCreateByEmailResponse>;
+    /** @deprecated since version 3.0. Will be deleted in version 4.0.  Use magicLinks.email.invite instead. */
+    inviteByEmail(data: magicLinks.InviteByEmailRequest): Promise<magicLinks.InviteByEmailResponse>;
+    /** @deprecated since version 3.0. Will be deleted in version 4.0.  Use magicLinks.email.revokeInvite instead. */
+    revokePendingInvite(data: magicLinks.RevokePendingInviteByEmailRequest): Promise<magicLinks.RevokePendingInviteByEmailResponse>;
+    /** @deprecated since version 3.0. Will be deleted in version 4.0.  Use magicLinks.authenticate instead. */
+    authenticateMagicLink(token: string, data?: magicLinks.AuthenticateRequest): Promise<magicLinks.AuthenticateResponse>;
+    /** @deprecated since version 3.0. Will be deleted in version 4.0.  Use otps.sms.send instead. */
+    sendOTPBySMS(data: otps.SendOTPBySMSRequest): Promise<otps.SendOTPBySMSResponse>;
+    /** @deprecated since version 3.0. Will be deleted in version 4.0.  Use otps.sms.loginOrCreate instead. */
+    loginOrCreateUserBySMS(data: otps.LoginOrCreateUserBySMSRequest): Promise<otps.LoginOrCreateUserBySMSResponse>;
+    /** @deprecated since version 3.0. Will be deleted in version 4.0.  Use otps.authenticate instead. */
+    authenticateOTP(data: otps.AuthenticateRequest): Promise<otps.AuthenticateResponse>;
 }
 export {};


### PR DESCRIPTION
The simple method aliasing in #34 didn't actually work. Calling one of those methods results in a TypeError saying `this.endpoint` is not a function, which makes sense in retrospect, since `endpoint` isn't bound to the constructed object.

To actually get the claimed backward compatibility (and avoid further problems with `this`), I've turned the alias methods into real methods that forward their arguments to the namespaced ones.

# Testing

There's a new integration test for one of the alias methods. All the others follow the same pattern, so we should be able to get away with just this one test.

# Reviewer notes

Remember that `/dist` and `/types` are entirely generated code.