### PR TITLE
fix: Unpack axios errors for better debugging

### DIFF
--- a/dist/errors.js
+++ b/dist/errors.js
@@ -3,7 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.StytchError = void 0;
+exports.RequestError = exports.StytchError = void 0;
 
 class StytchError extends Error {
   constructor(data) {
@@ -18,3 +18,13 @@ class StytchError extends Error {
 }
 
 exports.StytchError = StytchError;
+
+class RequestError extends Error {
+  constructor(message, request) {
+    super(message);
+    this.request = request;
+  }
+
+}
+
+exports.RequestError = RequestError;

--- a/dist/shared.js
+++ b/dist/shared.js
@@ -5,18 +5,19 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.request = request;
 
-var _stytch_error = require("./stytch_error");
+var _errors = require("./errors");
 
 function request(client, config) {
   return client.request(config).then(res => res.data).catch(err => {
     if (err.response) {
-      throw new _stytch_error.StytchError(err.response.data);
+      // Received a structured error from the API
+      throw new _errors.StytchError(err.response.data);
     } else if (err.request) {
       // No response received for the request.
-      throw new Error(err.request);
+      throw new _errors.RequestError(err.message, err.config);
     } else {
       // The request couldn't be sent for some reason.
-      throw new Error(err.message);
+      throw new _errors.RequestError(err.message, config);
     }
   });
 }

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -1,3 +1,5 @@
+import type { AxiosRequestConfig } from "axios";
+
 export class StytchError extends Error {
   status_code: number;
   request_id: string;
@@ -18,5 +20,14 @@ export class StytchError extends Error {
     this.error_type = data.error_type;
     this.error_message = data.error_message;
     this.error_url = data.error_url;
+  }
+}
+
+export class RequestError extends Error {
+  request: AxiosRequestConfig;
+
+  constructor(message: string, request: AxiosRequestConfig) {
+    super(message);
+    this.request = request;
   }
 }

--- a/lib/shared.ts
+++ b/lib/shared.ts
@@ -1,4 +1,4 @@
-import { StytchError } from "./stytch_error";
+import { StytchError, RequestError } from "./errors";
 
 import type { AxiosInstance, AxiosRequestConfig } from "axios";
 
@@ -39,13 +39,14 @@ export function request<T>(
     .then((res) => res.data)
     .catch((err) => {
       if (err.response) {
+        // Received a structured error from the API
         throw new StytchError(err.response.data);
       } else if (err.request) {
         // No response received for the request.
-        throw new Error(err.request);
+        throw new RequestError(err.message, err.config);
       } else {
         // The request couldn't be sent for some reason.
-        throw new Error(err.message);
+        throw new RequestError(err.message, config);
       }
     });
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stytch",
-  "version": "3.0.0-beta.3",
+  "version": "3.0.0-beta.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "stytch",
-      "version": "3.0.0-beta.3",
+      "version": "3.0.0-beta.4",
       "license": "MIT",
       "dependencies": {
         "axios": "^0.21.1",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "url": "git://github.com/stytchauth/stytch-node.git"
   },
   "scripts": {
-    "build": "babel lib --out-dir dist --extensions '.ts' && tsc --declaration --outDir types --emitDeclarationOnly",
+    "build": "rm -rf dist types && babel lib --out-dir dist --extensions '.ts' && tsc --declaration --outDir types --emitDeclarationOnly",
     "lint": "eslint lib",
     "test": "jest",
     "test-packages": "./test-packages/test.sh"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stytch",
-  "version": "3.0.0-beta.3",
+  "version": "3.0.0-beta.4",
   "description": "A wrapper for the Stytch API",
   "types": "./types/lib/index.d.ts",
   "main": "./dist/index.js",

--- a/test/shared.test.ts
+++ b/test/shared.test.ts
@@ -4,7 +4,7 @@ import { request } from "../lib/shared";
 import type { AxiosRequestConfig } from "axios";
 
 describe("request", () => {
-  test("successful response", () => {
+  test("successful response returns data", () => {
     expect.assertions(2);
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -18,7 +18,7 @@ describe("request", () => {
     ).resolves.toEqual({ key: "value" });
   });
 
-  test("error response", () => {
+  test("error response throws inspectable error", () => {
     expect.assertions(2);
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -48,5 +48,35 @@ describe("request", () => {
         });
       }
     );
+  });
+
+  test("no response rethrows original error", () => {
+    expect.assertions(3);
+
+    const client = axios.create();
+    return request(client, { url: "nowhere" }).catch((err) => {
+      expect(err.toString()).toEqual(
+        "Error: connect ECONNREFUSED 127.0.0.1:80"
+      );
+      expect(err.message).toEqual("connect ECONNREFUSED 127.0.0.1:80");
+      expect(err.request).toMatchObject({
+        url: "nowhere",
+      });
+    });
+  });
+
+  test("unsendable request rethrows original error", () => {
+    expect.assertions(3);
+
+    const client = axios.create();
+    return request(client, { url: "" }).catch((err) => {
+      expect(err.toString()).toEqual(
+        "Error: Cannot read property 'replace' of null"
+      );
+      expect(err.message).toEqual("Cannot read property 'replace' of null");
+      expect(err.request).toMatchObject({
+        url: "",
+      });
+    });
   });
 });

--- a/types/lib/errors.d.ts
+++ b/types/lib/errors.d.ts
@@ -1,3 +1,4 @@
+import type { AxiosRequestConfig } from "axios";
 export declare class StytchError extends Error {
     status_code: number;
     request_id: string;
@@ -11,4 +12,8 @@ export declare class StytchError extends Error {
         error_message: string;
         error_url: string;
     });
+}
+export declare class RequestError extends Error {
+    request: AxiosRequestConfig;
+    constructor(message: string, request: AxiosRequestConfig);
 }


### PR DESCRIPTION
When using a client with an invalid Stytch env (for example, local testing without the server running), the error messages from endpoint methods were difficult to work with (the dreaded "[object Object]"). To make these debuggable, we now unpack the axios error into useful parts as a dedicated `RequestError` type.

# Testing

There are new unit tests covering both cases.

Example error messages:
* Old
  ```
  Error: [object Object]
      at /.../node_modules/stytch/dist/shared.js:16:13
      at processTicksAndRejections (internal/process/task_queues.js:95:5)
  ```
* New
  ```
  RequestError: connect ECONNREFUSED 127.0.0.1:8080
      at /.../node_modules/stytch/dist/shared.js:17:13
      at processTicksAndRejections (internal/process/task_queues.js:95:5) {
    request: {
      url: ...,
      method: ...,
      data: ...,
      headers: ...,
      ...
    }
  }
  ```