### PR TITLE
fix: Handle response errors for users endpoints

### DIFF
--- a/dist/users.js
+++ b/dist/users.js
@@ -5,6 +5,8 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.Users = void 0;
 
+var _shared = require("./shared");
+
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 
 class Users {
@@ -18,39 +20,56 @@ class Users {
     return `${this.base_path}/${path}`;
   }
 
-  create(request) {
-    return this.client.post("users", {
-      body: request
+  create(data) {
+    return (0, _shared.request)(this.client, {
+      method: "POST",
+      url: this.base_path,
+      data
     });
   }
 
   get(userID) {
-    return this.client.get(this.endpoint(userID));
+    return (0, _shared.request)(this.client, {
+      method: "GET",
+      url: this.endpoint(userID)
+    });
   }
 
-  update(userID, request) {
-    return this.client.put(this.endpoint(userID), {
-      body: request
+  update(userID, data) {
+    return (0, _shared.request)(this.client, {
+      method: "PUT",
+      url: this.endpoint(userID),
+      data
     });
   }
 
   delete(userID) {
-    return this.client.delete(this.endpoint(userID));
+    return (0, _shared.request)(this.client, {
+      method: "DELETE",
+      url: this.endpoint(userID)
+    });
   }
 
-  getPending(request) {
-    const params = request || {};
-    return this.client.get(this.endpoint("pending"), {
+  getPending(params) {
+    return (0, _shared.request)(this.client, {
+      method: "GET",
+      url: this.endpoint("pending"),
       params
     });
   }
 
   deleteEmail(emailID) {
-    return this.delete(this.endpoint(`emails/${emailID}`));
+    return (0, _shared.request)(this.client, {
+      method: "DELETE",
+      url: this.endpoint(`emails/${emailID}`)
+    });
   }
 
   deletePhoneNumber(phoneID) {
-    return this.delete(this.endpoint(`phone_numbers/${phoneID}`));
+    return (0, _shared.request)(this.client, {
+      method: "DELETE",
+      url: this.endpoint(`phone_numbers/${phoneID}`)
+    });
   }
 
 }

--- a/lib/users.ts
+++ b/lib/users.ts
@@ -1,3 +1,5 @@
+import { request } from "./shared";
+
 import type { AxiosInstance } from "axios";
 import type {
   Attributes,
@@ -90,32 +92,55 @@ export class Users {
     return `${this.base_path}/${path}`;
   }
 
-  create(request: CreateRequest): Promise<CreateResponse> {
-    return this.client.post("users", { body: request });
+  create(data: CreateRequest): Promise<CreateResponse> {
+    return request(this.client, {
+      method: "POST",
+      url: this.base_path,
+      data,
+    });
   }
 
   get(userID: UserID): Promise<GetResponse> {
-    return this.client.get(this.endpoint(userID));
+    return request(this.client, {
+      method: "GET",
+      url: this.endpoint(userID),
+    });
   }
 
-  update(userID: UserID, request: UpdateRequest): Promise<UpdateResponse> {
-    return this.client.put(this.endpoint(userID), { body: request });
+  update(userID: UserID, data: UpdateRequest): Promise<UpdateResponse> {
+    return request(this.client, {
+      method: "PUT",
+      url: this.endpoint(userID),
+      data,
+    });
   }
 
   delete(userID: UserID): Promise<DeleteResponse> {
-    return this.client.delete(this.endpoint(userID));
+    return request(this.client, {
+      method: "DELETE",
+      url: this.endpoint(userID),
+    });
   }
 
-  getPending(request?: GetPendingRequest): Promise<GetPendingResponse> {
-    const params: GetPendingRequest = request || {};
-    return this.client.get(this.endpoint("pending"), { params });
+  getPending(params?: GetPendingRequest): Promise<GetPendingResponse> {
+    return request(this.client, {
+      method: "GET",
+      url: this.endpoint("pending"),
+      params,
+    });
   }
 
   deleteEmail(emailID: string): Promise<DeleteEmailResponse> {
-    return this.delete(this.endpoint(`emails/${emailID}`));
+    return request(this.client, {
+      method: "DELETE",
+      url: this.endpoint(`emails/${emailID}`),
+    });
   }
 
   deletePhoneNumber(phoneID: string): Promise<DeletePhoneNumberResponse> {
-    return this.delete(this.endpoint(`phone_numbers/${phoneID}`));
+    return request(this.client, {
+      method: "DELETE",
+      url: this.endpoint(`phone_numbers/${phoneID}`),
+    });
   }
 }

--- a/lib/users.ts
+++ b/lib/users.ts
@@ -45,8 +45,8 @@ export interface GetResponse extends BaseResponse {
 
 export interface UpdateRequest {
   name?: Name;
-  emails?: string[];
-  phone_numbers?: string[];
+  emails?: { email: string }[];
+  phone_numbers?: { phone_number: string }[];
   attributes?: Attributes;
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stytch",
-  "version": "3.0.0-beta.4",
+  "version": "3.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "stytch",
-      "version": "3.0.0-beta.4",
+      "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^0.21.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stytch",
-  "version": "3.0.0-beta.4",
+  "version": "3.0.0",
   "description": "A wrapper for the Stytch API",
   "types": "./types/lib/index.d.ts",
   "main": "./dist/index.js",

--- a/test/otps.test.ts
+++ b/test/otps.test.ts
@@ -52,12 +52,12 @@ describe("otps.sms.send", () => {
 describe("otps.sms.loginOrCreate", () => {
   test("success", () => {
     return expect(
-      otps.sms.send({
+      otps.sms.loginOrCreate({
         phone_number: "+12025550162",
       })
     ).resolves.toMatchObject({
       method: "post",
-      path: "otps/sms/send",
+      path: "otps/sms/login_or_create",
       data: {
         phone_number: "+12025550162",
       },
@@ -84,12 +84,12 @@ describe("otps.whatsapp.send", () => {
 describe("otps.whatsapp.loginOrCreate", () => {
   test("success", () => {
     return expect(
-      otps.whatsapp.send({
+      otps.whatsapp.loginOrCreate({
         phone_number: "+12025550162",
       })
     ).resolves.toMatchObject({
       method: "post",
-      path: "otps/whatsapp/send",
+      path: "otps/whatsapp/login_or_create",
       data: {
         phone_number: "+12025550162",
       },

--- a/test/users.test.ts
+++ b/test/users.test.ts
@@ -1,0 +1,139 @@
+import axios from "axios";
+import { Users } from "../lib/users";
+
+import type { AxiosRequestConfig } from "axios";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const adapter = (config: AxiosRequestConfig): Promise<any> => {
+  return Promise.resolve({
+    data: {
+      method: config.method,
+      path: config.url,
+      data: config.data && JSON.parse(config.data),
+      params: config.params,
+    },
+  });
+};
+const users = new Users(axios.create({ adapter }));
+
+describe("users.create", () => {
+  test("success", () => {
+    return expect(
+      users.create({
+        email: "sandbox@stytch.com",
+      })
+    ).resolves.toMatchObject({
+      method: "post",
+      path: "users",
+      data: {
+        email: "sandbox@stytch.com",
+      },
+    });
+  });
+});
+
+describe("users.get", () => {
+  test("success", () => {
+    return expect(
+      users.get("user-test-22222222-2222-4222-8222-222222222222")
+    ).resolves.toMatchObject({
+      method: "get",
+      path: "users/user-test-22222222-2222-4222-8222-222222222222",
+    });
+  });
+});
+
+describe("users.update", () => {
+  test("success", () => {
+    return expect(
+      users.update("user-test-22222222-2222-4222-8222-222222222222", {
+        name: {
+          first_name: "First",
+          last_name: "Last",
+        },
+        emails: [{ email: "sandbox@stytch.com" }],
+        phone_numbers: [{ phone_number: "+12025550162" }],
+      })
+    ).resolves.toMatchObject({
+      method: "put",
+      path: "users/user-test-22222222-2222-4222-8222-222222222222",
+      data: {
+        name: {
+          first_name: "First",
+          last_name: "Last",
+        },
+        emails: [{ email: "sandbox@stytch.com" }],
+        phone_numbers: [{ phone_number: "+12025550162" }],
+      },
+    });
+  });
+});
+
+describe("users.delete", () => {
+  test("success", () => {
+    return expect(
+      users.delete("user-test-22222222-2222-4222-8222-222222222222")
+    ).resolves.toMatchObject({
+      method: "delete",
+      path: "users/user-test-22222222-2222-4222-8222-222222222222",
+    });
+  });
+});
+
+describe("users.getPending", () => {
+  test("no arguments", () => {
+    return expect(users.getPending()).resolves.toMatchObject({
+      method: "get",
+      path: "users/pending",
+      params: {},
+    });
+  });
+
+  test("both arguments", () => {
+    return expect(
+      users.getPending({
+        starting_after_id: "user-test-e3795c81-f849-4167-bfda-e4a6e9c280fd",
+        limit: BigInt(10),
+      })
+    ).resolves.toMatchObject({
+      method: "get",
+      path: "users/pending",
+      params: {
+        starting_after_id: "user-test-e3795c81-f849-4167-bfda-e4a6e9c280fd",
+        limit: BigInt(10),
+      },
+    });
+  });
+
+  test("empty params object", () => {
+    return expect(users.getPending({})).resolves.toMatchObject({
+      method: "get",
+      path: "users/pending",
+      params: {},
+    });
+  });
+});
+
+describe("users.deleteEmail", () => {
+  test("success", () => {
+    return expect(
+      users.deleteEmail("email-test-33333333-3333-4333-8333-333333333333")
+    ).resolves.toMatchObject({
+      method: "delete",
+      path: "users/emails/email-test-33333333-3333-4333-8333-333333333333",
+    });
+  });
+});
+
+describe("users.deletePhoneNumber", () => {
+  test("success", () => {
+    return expect(
+      users.deletePhoneNumber(
+        "phone-number-test-33333333-3333-4333-8333-333333333333"
+      )
+    ).resolves.toMatchObject({
+      method: "delete",
+      path: "users/phone_numbers/phone-number-test-33333333-3333-4333-8333-333333333333",
+    });
+  });
+});

--- a/types/lib/users.d.ts
+++ b/types/lib/users.d.ts
@@ -31,8 +31,12 @@ export interface GetResponse extends BaseResponse {
 }
 export interface UpdateRequest {
     name?: Name;
-    emails?: string[];
-    phone_numbers?: string[];
+    emails?: {
+        email: string;
+    }[];
+    phone_numbers?: {
+        phone_number: string;
+    }[];
     attributes?: Attributes;
 }
 export interface UpdateResponse extends BaseResponse {
@@ -64,11 +68,11 @@ export declare class Users {
     private client;
     constructor(client: AxiosInstance);
     private endpoint;
-    create(request: CreateRequest): Promise<CreateResponse>;
+    create(data: CreateRequest): Promise<CreateResponse>;
     get(userID: UserID): Promise<GetResponse>;
-    update(userID: UserID, request: UpdateRequest): Promise<UpdateResponse>;
+    update(userID: UserID, data: UpdateRequest): Promise<UpdateResponse>;
     delete(userID: UserID): Promise<DeleteResponse>;
-    getPending(request?: GetPendingRequest): Promise<GetPendingResponse>;
+    getPending(params?: GetPendingRequest): Promise<GetPendingResponse>;
     deleteEmail(emailID: string): Promise<DeleteEmailResponse>;
     deletePhoneNumber(phoneID: string): Promise<DeletePhoneNumberResponse>;
 }


### PR DESCRIPTION
This fixes a bug from the refactor to namespaced endpoints (#34). The `users` endpoints weren't using the shared `request` error handling, which threw unstructured errors from calls like `client.users.get("does-not-exist")`.

This also includes some other related changes:
- Correct the type signature for `users.update`/`updateUser`.  As originally typed, this call would construct an invalid request body.
- Fix copy-paste errors in OTPs unit tests

# Testing

There are now unit tests for the `users` endpoints to verify the request config.

# Reviewer Notes

After upgrading our example apps through the betas, playing in a REPL, and reaching near-100% test coverage, I think this is ready to be called a stable v3, so I've removed the beta tag! 