### PR TITLE
docs: Update README to include runnable examples

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,74 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at alex@stytch.com. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at [https://contributor-covenant.org/version/1/4][version]
+
+[homepage]: https://contributor-covenant.org
+[version]: https://contributor-covenant.org/version/1/4/

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -55,7 +55,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at alex@stytch.com. All
+reported by contacting the project team at support@stytch.com. All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,45 @@
+# Development
+
+Thanks for contributing to Stytch's Node library! If you run into trouble, find us in [Slack](slack).
+
+## Setup
+
+1. Install a supported stable release of [Node](https://nodejs.org/).
+2. Clone this repo.
+3. Run `npm install`.
+
+## Source Files
+
+The source code in this repo is in `lib` and written entirely in TypeScript.
+
+## Generated Files
+
+Run `npm run build` to generate the distributed JavaScript (`dist`) and TypeScript declarations (`types`). Commit these and include them in pull requests.
+
+### Why do we commit generated code?
+
+We only package `dist` and `types` when publishing to NPM. To make sure our published files are version-controlled and tied to the original source, we commit them to the repo.
+
+## Testing
+
+Please include tests for your changes. We don't have a test coverage requirement, but we like our test suite to give us reasonable confidence that everything works as intended.
+
+### Unit Tests
+
+Run `npm test`
+
+### Integration Tests
+
+Export the following environment variables and then run `npm test`:
+
+- `PROJECT_ID='project-test-...'` is your Stytch test project ID
+- `SECRET='secret-test-...'` is your Stytch test secret
+- `RUN_INTEGRATION_TESTS=1` un-skips integration tests
+
+## Issues and Pull Requests
+
+Please file issues and open pull requests in this repo. We'll have description templates for those soon, but for now, say whatever you think is important!
+
+When you're ready for someone to look at your issue or PR, assign `@stytchauth/node`. If we don't acknowledge it within one business day, please escalate it by tagging `@stytchauth/engineering` in a comment or letting us know in [Slack](slack).
+
+[slack]: https://join.slack.com/t/stytch/shared_invite/zt-nil4wo92-jApJ9Cl32cJbEd9esKkvyg

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -42,6 +42,6 @@ Please file issues in this repo. We don't have an issue template yet, but for no
 
 If you have non-trivial changes you'd like us to incorporate, please open an issue first so we can discuss the changes before starting on a pull request. (It's fine to start with the PR for a typo or simple bug.) If we think the changes align with the direction of the project, we'll either ask you to open the PR or assign someone on the Stytch team to make the changes.
 
-When you're ready for someone to look at your issue or PR, assign `@stytchauth/node`. If we don't acknowledge it within one business day, please escalate it by tagging `@stytchauth/engineering` in a comment or letting us know in [Slack].
+When you're ready for someone to look at your issue or PR, assign `@stytchauth/engineering`. If we don't acknowledge it within one business day, please escalate it by tagging `@stytchauth/engineering` in a comment or letting us know in [Slack].
 
 [Slack]: https://join.slack.com/t/stytch/shared_invite/zt-nil4wo92-jApJ9Cl32cJbEd9esKkvyg

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,6 +1,6 @@
 # Development
 
-Thanks for contributing to Stytch's Node library! If you run into trouble, find us in [Slack](slack).
+Thanks for contributing to Stytch's Node library! If you run into trouble, find us in [Slack].
 
 ## Setup
 
@@ -40,6 +40,6 @@ Export the following environment variables and then run `npm test`:
 
 Please file issues and open pull requests in this repo. We'll have description templates for those soon, but for now, say whatever you think is important!
 
-When you're ready for someone to look at your issue or PR, assign `@stytchauth/node`. If we don't acknowledge it within one business day, please escalate it by tagging `@stytchauth/engineering` in a comment or letting us know in [Slack](slack).
+When you're ready for someone to look at your issue or PR, assign `@stytchauth/node`. If we don't acknowledge it within one business day, please escalate it by tagging `@stytchauth/engineering` in a comment or letting us know in [Slack].
 
-[slack]: https://join.slack.com/t/stytch/shared_invite/zt-nil4wo92-jApJ9Cl32cJbEd9esKkvyg
+[Slack]: https://join.slack.com/t/stytch/shared_invite/zt-nil4wo92-jApJ9Cl32cJbEd9esKkvyg

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -38,7 +38,9 @@ Export the following environment variables and then run `npm test`:
 
 ## Issues and Pull Requests
 
-Please file issues and open pull requests in this repo. We'll have description templates for those soon, but for now, say whatever you think is important!
+Please file issues in this repo. We don't have an issue template yet, but for now, say whatever you think is important!
+
+If you have non-trivial changes you'd like us to incorporate, please open an issue first so we can discuss the changes before starting on a pull request. (It's fine to start with the PR for a typo or simple bug.) If we think the changes align with the direction of the project, we'll either ask you to open the PR or assign someone on the Stytch team to make the changes.
 
 When you're ready for someone to look at your issue or PR, assign `@stytchauth/node`. If we don't acknowledge it within one business day, please escalate it by tagging `@stytchauth/engineering` in a comment or letting us know in [Slack].
 

--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ Send a magic link by email:
 client.magicLinks.email
   .loginOrCreate({
     email: "sandbox@stytch.com",
-    login_magic_link_url: "https://www.stytch.com/login",
-    signup_magic_link_url: "https://www.stytch.com/signup",
+    login_magic_link_url: "https://example.com/authenticate",
+    signup_magic_link_url: "https://example.com/authenticate",
   })
   .then((res) => console.log(res))
   .catch((err) => console.error(err));

--- a/README.md
+++ b/README.md
@@ -1,49 +1,87 @@
-# stytch-node
+# Stytch Node.js Library
 
-The Stytch Node library provides support for the Stytch API for server-side Javscript
-applications. You can find out more about the Stytch API at
-[stytch.com/docs](https://stytch.com/docs).
+The Stytch Node library makes it easy to use the Stytch user infrastructure API in server-side JavaScript applications.
 
-If you're looking for frontend support for our Javascript SDK, check out
-[stytch-js](https://www.npmjs.com/package/@stytch/stytch-js).
+It pairs well with the Stytch [Web SDK](https://www.npmjs.com/package/@stytch/stytch-js) or your own custom authentication flow.
 
-## Quickstart
+## Install
 
-Install stytch
 ```
 npm install stytch
+# or
+yarn add stytch
 ```
 
-Run `login_or_create` to send a magic link by email:
+## Usage
 
+You can find your API credentials in the [Stytch Dashboard](https://stytch.com/dashboard/api-keys).
+
+Create an API client:
 ```javascript
 import * as stytch from "stytch";
 // Or as a CommonJS module:
 // const stytch = require("stytch");
 
 const client = new stytch.Client({
-  project_id: "PROJECT_ID",
-  secret: "SECRET",
+  project_id: "project-live-c60c0abe-c25a-4472-a9ed-320c6667d317",
+  secret: "secret-live-80JASucyk7z_G8Z-7dVwZVGXL5NT_qGAQ2I=",
   env: stytch.envs.test,
 });
+```
 
+Send a magic link by email:
+```javascript
 client.magicLinks.email
   .loginOrCreate({
     email: "sandbox@stytch.com",
-    login_magic_link_url: "http://localhost:8000/login",
-    signup_magic_link_url: "http://localhost:8000/signup",
+    login_magic_link_url: "https://www.stytch.com/login",
+    signup_magic_link_url: "https://www.stytch.com/signup",
   })
-  .then((res) => console.log(res))
-  .catch((err) => console.error(err));
-
-client.magicLinks
-  .authenticate("TOKEN FROM EMAIL")
   .then((res) => console.log(res))
   .catch((err) => console.error(err));
 ```
 
+Authenticate the token from the magic link:
+```javascript
+client.magicLinks
+  .authenticate("DOYoip3rvIMMW5lgItikFK-Ak1CfMsgjuiCyI7uuU94=")
+  .then((res) => console.log(res))
+  .catch((err) => console.error(err));
+```
+
+## Handling Errors
+
+Stytch errors always include an `error_type` field you can use to identify them:
+```javascript
+client.magicLinks
+  .authenticate("not-a-token!")
+  .then((res) => console.log(res))
+  .catch((err) => {
+    if (err.error_type === "invalid_token") {
+      console.log("Whoops! Try again?");
+    }
+  });
+```
+Learn more about errors in the [docs](https://stytch.com/docs/api/errors).
+
 ## Documentation
 
-You can find all the documentation at https://stytch.com/docs, including an
-[API reference](https://stytch.com/docs/api) with example usage for every endpoint.  We also
-maintain a set of [example apps](https://stytch.com/docs/example-apps) to start development from.
+See example requests and responses for all the endpoints in the [Stytch API Reference](https://stytch.com/docs/api).
+
+Follow one of the [integration guides](https://stytch.com/docs/guides) or start with one of our [example apps](https://stytch.com/docs/example-apps).
+
+## Support
+
+If you've found a bug, [open an issue](issues/new)!
+
+If you have questions or want help troubleshooting, join us in [Slack](https://join.slack.com/t/stytch/shared_invite/zt-nil4wo92-jApJ9Cl32cJbEd9esKkvyg) or email support@stytch.com.
+
+If you've found a security vulnerability, please follow our [responsible disclosure instructions](https://stytch.com/docs/security).
+
+## Development
+
+See [DEVELOPMENT.md](DEVELOPMENT.md)
+
+## Code of Conduct
+
+Everyone interacting in the Stytch project's codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](CODE_OF_CONDUCT.md).

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Follow one of the [integration guides](https://stytch.com/docs/guides) or start 
 
 ## Support
 
-If you've found a bug, [open an issue](issues/new)!
+If you've found a bug, [open an issue](https://github.com/stytchauth/stytch-node/issues/new)!
 
 If you have questions or want help troubleshooting, join us in [Slack](https://join.slack.com/t/stytch/shared_invite/zt-nil4wo92-jApJ9Cl32cJbEd9esKkvyg) or email support@stytch.com.
 


### PR DESCRIPTION
Update the README to use example credentials and tokens so they return "good" errors instead of 401s.

While I was here, I aligned the repo docs with our new standard template.
