### PR TITLE
docs: Switch README example from ES6 to CJS

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ You can find your API credentials in the [Stytch Dashboard](https://stytch.com/d
 
 Create an API client:
 ```javascript
-import * as stytch from "stytch";
-// Or as a CommonJS module:
-// const stytch = require("stytch");
+const stytch = require("stytch");
+// Or as an ES6 module:
+// import * as stytch from "stytch";
 
 const client = new stytch.Client({
   project_id: "project-live-c60c0abe-c25a-4472-a9ed-320c6667d317",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stytch",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "stytch",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "license": "MIT",
       "dependencies": {
         "axios": "^0.21.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stytch",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "A wrapper for the Stytch API",
   "types": "./types/lib/index.d.ts",
   "main": "./dist/index.js",


### PR DESCRIPTION
Copy-pasting the example code into a REPL in a SyntaxError because import statements aren't allowed in that context.  To make copy-pasting work in more places, switch the example to CommonJS style.
