### PR TITLE
fix: Include ES6 module wrapper in published package

### DIFF
--- a/index.cjs
+++ b/index.cjs
@@ -1,1 +1,0 @@
-module.exports = require("./dist");

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stytch",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "stytch",
-      "version": "3.0.1",
+      "version": "3.0.2",
       "license": "MIT",
       "dependencies": {
         "axios": "^0.21.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stytch",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "A wrapper for the Stytch API",
   "types": "./types/lib/index.d.ts",
   "main": "./dist/index.js",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   },
   "files": [
     "dist/**/*",
-    "types/**/*"
+    "types/**/*",
+    "module.mjs"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
This wrapper is required by the `exports.import` field in `package.json`, but it was omitted from the published package.  This prevented an ES6 module import from being able to find the package.

The `index.cjs` file was also omitted from the published package for the same reason, which implies we don't need it anyway.

Errors look like this:
```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '.../node_modules/stytch/module.mjs' imported from .../test.js
Did you mean to import stytch/dist/index.js?
```
