### PR TITLE
fix: Use number instead of bigint for numeric types

### DIFF
--- a/lib/magic_links.ts
+++ b/lib/magic_links.ts
@@ -7,8 +7,8 @@ export interface SendByEmailRequest {
   email: string;
   login_magic_link_url: string;
   signup_magic_link_url: string;
-  login_expiration_minutes?: bigint;
-  signup_expiration_minutes?: bigint;
+  login_expiration_minutes?: number;
+  signup_expiration_minutes?: number;
   attributes?: Attributes;
 }
 
@@ -21,8 +21,8 @@ export interface LoginOrCreateByEmailRequest {
   email: string;
   login_magic_link_url: string;
   signup_magic_link_url: string;
-  login_expiration_minutes?: bigint;
-  signup_expiration_minutes?: bigint;
+  login_expiration_minutes?: number;
+  signup_expiration_minutes?: number;
   create_user_as_pending?: boolean;
   attributes?: Attributes;
 }
@@ -36,7 +36,7 @@ export interface LoginOrCreateByEmailResponse extends BaseResponse {
 export interface InviteByEmailRequest {
   email: string;
   invite_magic_link_url: string;
-  invite_expiration_minutes?: bigint;
+  invite_expiration_minutes?: number;
   name?: Name;
   attributes?: Attributes;
 }

--- a/lib/otps.ts
+++ b/lib/otps.ts
@@ -5,7 +5,7 @@ import type { Attributes, BaseResponse, Session } from "./shared";
 
 export interface OTPEmailSendRequest {
   email: string;
-  expiration_minutes?: bigint;
+  expiration_minutes?: number;
   attributes?: Attributes;
 }
 
@@ -16,7 +16,7 @@ export interface OTPEmailSendResponse extends BaseResponse {
 
 export interface OTPEmailLoginOrCreateRequest {
   email: string;
-  expiration_minutes?: bigint;
+  expiration_minutes?: number;
   attributes?: Attributes;
   create_user_as_pending?: boolean;
 }
@@ -29,7 +29,7 @@ export interface OTPEmailLoginOrCreateResponse extends BaseResponse {
 
 export interface SendOTPBySMSRequest {
   phone_number: string;
-  expiration_minutes?: bigint;
+  expiration_minutes?: number;
   attributes?: Attributes;
 }
 
@@ -40,7 +40,7 @@ export interface SendOTPBySMSResponse extends BaseResponse {
 
 export interface LoginOrCreateUserBySMSRequest {
   phone_number: string;
-  expiration_minutes?: bigint;
+  expiration_minutes?: number;
   attributes?: Attributes;
   create_user_as_pending?: boolean;
 }
@@ -53,7 +53,7 @@ export interface LoginOrCreateUserBySMSResponse extends BaseResponse {
 
 export interface OTPWhatsAppSendRequest {
   phone_number: string;
-  expiration_minutes?: bigint;
+  expiration_minutes?: number;
   attributes?: Attributes;
 }
 
@@ -64,7 +64,7 @@ export interface OTPWhatsAppSendResponse extends BaseResponse {
 
 export interface OTPWhatsAppLoginOrCreateRequest {
   phone_number: string;
-  expiration_minutes?: bigint;
+  expiration_minutes?: number;
   attributes?: Attributes;
   create_user_as_pending?: boolean;
 }

--- a/lib/shared.ts
+++ b/lib/shared.ts
@@ -35,7 +35,7 @@ export interface Session {
 }
 
 export interface BaseResponse {
-  status_code: bigint;
+  status_code: number;
   request_id: string;
 }
 

--- a/lib/users.ts
+++ b/lib/users.ts
@@ -62,14 +62,14 @@ export interface DeleteResponse extends BaseResponse {
 
 export interface GetPendingRequest {
   starting_after_id?: string;
-  limit?: bigint;
+  limit?: number;
 }
 
 export interface GetPendingResponse extends BaseResponse {
   users: PendingUser[];
   has_more: boolean;
   starting_after_id: string;
-  total: bigint;
+  total: number;
 }
 
 export interface DeleteEmailResponse extends BaseResponse {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stytch",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "stytch",
-      "version": "3.2.0",
+      "version": "3.2.1",
       "license": "MIT",
       "dependencies": {
         "axios": "^0.21.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stytch",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "A wrapper for the Stytch API",
   "types": "./types/lib/index.d.ts",
   "main": "./dist/index.js",

--- a/test/magic_links.test.ts
+++ b/test/magic_links.test.ts
@@ -46,7 +46,7 @@ describe("magicLinks.authenticate", () => {
 });
 
 describe("magicLinks.email.send", () => {
-  test("success", () => {
+  test("success: minimal", () => {
     return expect(
       magicLinks.email.send({
         email: "sandbox@stytch.com",
@@ -60,6 +60,35 @@ describe("magicLinks.email.send", () => {
         email: "sandbox@stytch.com",
         login_magic_link_url: "http://localhost:8000/login",
         signup_magic_link_url: "http://localhost:8000/signup",
+      },
+    });
+  });
+  test("success: everything", () => {
+    return expect(
+      magicLinks.email.send({
+        email: "sandbox@stytch.com",
+        login_magic_link_url: "http://localhost:8000/login",
+        signup_magic_link_url: "http://localhost:8000/signup",
+        login_expiration_minutes: 10,
+        signup_expiration_minutes: 10,
+        attributes: {
+          user_agent: "Toaster/3.0",
+          ip_address: "203.0.113.1",
+        },
+      })
+    ).resolves.toMatchObject({
+      method: "post",
+      path: "magic_links/email/send",
+      data: {
+        email: "sandbox@stytch.com",
+        login_magic_link_url: "http://localhost:8000/login",
+        signup_magic_link_url: "http://localhost:8000/signup",
+        login_expiration_minutes: 10,
+        signup_expiration_minutes: 10,
+        attributes: {
+          user_agent: "Toaster/3.0",
+          ip_address: "203.0.113.1",
+        },
       },
     });
   });

--- a/test/shared.test.ts
+++ b/test/shared.test.ts
@@ -64,19 +64,4 @@ describe("request", () => {
       });
     });
   });
-
-  test("unsendable request rethrows original error", () => {
-    expect.assertions(3);
-
-    const client = axios.create();
-    return request(client, { url: "" }).catch((err) => {
-      expect(err.toString()).toEqual(
-        "Error: Cannot read property 'replace' of null"
-      );
-      expect(err.message).toEqual("Cannot read property 'replace' of null");
-      expect(err.request).toMatchObject({
-        url: "",
-      });
-    });
-  });
 });

--- a/test/users.test.ts
+++ b/test/users.test.ts
@@ -93,14 +93,14 @@ describe("users.getPending", () => {
     return expect(
       users.getPending({
         starting_after_id: "user-test-e3795c81-f849-4167-bfda-e4a6e9c280fd",
-        limit: BigInt(10),
+        limit: 10,
       })
     ).resolves.toMatchObject({
       method: "get",
       path: "users/pending",
       params: {
         starting_after_id: "user-test-e3795c81-f849-4167-bfda-e4a6e9c280fd",
-        limit: BigInt(10),
+        limit: 10,
       },
     });
   });

--- a/types/lib/magic_links.d.ts
+++ b/types/lib/magic_links.d.ts
@@ -5,8 +5,8 @@ export interface SendByEmailRequest {
     email: string;
     login_magic_link_url: string;
     signup_magic_link_url: string;
-    login_expiration_minutes?: bigint;
-    signup_expiration_minutes?: bigint;
+    login_expiration_minutes?: number;
+    signup_expiration_minutes?: number;
     attributes?: Attributes;
 }
 export interface SendByEmailResponse extends BaseResponse {
@@ -17,8 +17,8 @@ export interface LoginOrCreateByEmailRequest {
     email: string;
     login_magic_link_url: string;
     signup_magic_link_url: string;
-    login_expiration_minutes?: bigint;
-    signup_expiration_minutes?: bigint;
+    login_expiration_minutes?: number;
+    signup_expiration_minutes?: number;
     create_user_as_pending?: boolean;
     attributes?: Attributes;
 }
@@ -30,7 +30,7 @@ export interface LoginOrCreateByEmailResponse extends BaseResponse {
 export interface InviteByEmailRequest {
     email: string;
     invite_magic_link_url: string;
-    invite_expiration_minutes?: bigint;
+    invite_expiration_minutes?: number;
     name?: Name;
     attributes?: Attributes;
 }

--- a/types/lib/otps.d.ts
+++ b/types/lib/otps.d.ts
@@ -2,7 +2,7 @@ import type { AxiosInstance } from "axios";
 import type { Attributes, BaseResponse, Session } from "./shared";
 export interface OTPEmailSendRequest {
     email: string;
-    expiration_minutes?: bigint;
+    expiration_minutes?: number;
     attributes?: Attributes;
 }
 export interface OTPEmailSendResponse extends BaseResponse {
@@ -11,7 +11,7 @@ export interface OTPEmailSendResponse extends BaseResponse {
 }
 export interface OTPEmailLoginOrCreateRequest {
     email: string;
-    expiration_minutes?: bigint;
+    expiration_minutes?: number;
     attributes?: Attributes;
     create_user_as_pending?: boolean;
 }
@@ -22,7 +22,7 @@ export interface OTPEmailLoginOrCreateResponse extends BaseResponse {
 }
 export interface SendOTPBySMSRequest {
     phone_number: string;
-    expiration_minutes?: bigint;
+    expiration_minutes?: number;
     attributes?: Attributes;
 }
 export interface SendOTPBySMSResponse extends BaseResponse {
@@ -31,7 +31,7 @@ export interface SendOTPBySMSResponse extends BaseResponse {
 }
 export interface LoginOrCreateUserBySMSRequest {
     phone_number: string;
-    expiration_minutes?: bigint;
+    expiration_minutes?: number;
     attributes?: Attributes;
     create_user_as_pending?: boolean;
 }
@@ -42,7 +42,7 @@ export interface LoginOrCreateUserBySMSResponse extends BaseResponse {
 }
 export interface OTPWhatsAppSendRequest {
     phone_number: string;
-    expiration_minutes?: bigint;
+    expiration_minutes?: number;
     attributes?: Attributes;
 }
 export interface OTPWhatsAppSendResponse extends BaseResponse {
@@ -51,7 +51,7 @@ export interface OTPWhatsAppSendResponse extends BaseResponse {
 }
 export interface OTPWhatsAppLoginOrCreateRequest {
     phone_number: string;
-    expiration_minutes?: bigint;
+    expiration_minutes?: number;
     attributes?: Attributes;
     create_user_as_pending?: boolean;
 }

--- a/types/lib/shared.d.ts
+++ b/types/lib/shared.d.ts
@@ -27,7 +27,7 @@ export interface Session {
     attributes: Attributes;
 }
 export interface BaseResponse {
-    status_code: bigint;
+    status_code: number;
     request_id: string;
 }
 export declare function request<T>(client: AxiosInstance, config: AxiosRequestConfig): Promise<T>;

--- a/types/lib/users.d.ts
+++ b/types/lib/users.d.ts
@@ -49,13 +49,13 @@ export interface DeleteResponse extends BaseResponse {
 }
 export interface GetPendingRequest {
     starting_after_id?: string;
-    limit?: bigint;
+    limit?: number;
 }
 export interface GetPendingResponse extends BaseResponse {
     users: PendingUser[];
     has_more: boolean;
     starting_after_id: string;
-    total: bigint;
+    total: number;
 }
 export interface DeleteEmailResponse extends BaseResponse {
     user_id: UserID;


### PR DESCRIPTION
There are at least two problems with using `bigint`:
1. It only became available in ES2020, and it's rare to use that as a TS -> JS target.
2. It doesn't have a default JSON serialization, even as late as Node 16.

This PR changes `bigint` types to `number` types globally.

Versioning considerations: requests that used these fields didn't work at all with these TS types, so this is a bugfix.