### PR TITLE
dev: Bring back unsendable-request test

### DIFF
--- a/test/shared.test.ts
+++ b/test/shared.test.ts
@@ -64,4 +64,25 @@ describe("request", () => {
       });
     });
   });
+
+  test("unsendable request rethrows original error", () => {
+    // Using assertions instead of .rejects so we can check both .toString() and unpacked values
+    // in the same matcher.
+    expect.assertions(3);
+
+    const client = axios.create();
+    // BigInts don't serialize, which is weird, but that's useful to us here!
+    return request(client, {
+      url: "bigint",
+      data: { bigint: BigInt(10) },
+    }).catch((err) => {
+      expect(err.toString()).toEqual(
+        "Error: Do not know how to serialize a BigInt"
+      );
+      expect(err.message).toEqual("Do not know how to serialize a BigInt");
+      expect(err.request).toMatchObject({
+        url: "bigint",
+      });
+    });
+  });
 });


### PR DESCRIPTION
This test was removed without deep investigation during #51 because it was blocking the release.  My current hypothesis is that we were relying on internal axios error message strings, which broke in the upgrade from v0.21.1 to v0.21.3.

To make this test more reliable and more representative of a realistic error, force the BigInt serialization problem. As a bonus, if we can ever start relying on BigInts to serialize, this test will fail, which will prompt us to consider using them again.
