### PR TITLE
dev: Use `npm ci` in CI to avoid package.json changes

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: '16'
-      - run: npm install
+      - run: npm ci
       - run: npm test
 
   integration-test:
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: '16'
-      - run: npm install
+      - run: npm ci
       - run: npm test
         env:
           RUN_INTEGRATION_TESTS: 1
@@ -44,6 +44,6 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: '16'
-      - run: npm install
+      - run: npm ci
       - run: npm run build
       - run: git diff --exit-code


### PR DESCRIPTION
A recent update to prettier failed the [diff check](https://github.com/stytchauth/stytch-node/runs/3823879681#step:6) because `npm install` rewrote `package-lock.json` to use an exact version instead of a caret-version.

For prettier specifically, we do want to pin the exact version, per their [recommendations](https://prettier.io/docs/en/install.html#summary).

But CI shouldn't be writing to `package.json` or `package-lock.json` anyway, and `npm ci` solves that.
