### PR TITLE
fix: Throw an error when env is not a valid URL

### DIFF
--- a/dist/client.js
+++ b/dist/client.js
@@ -167,7 +167,7 @@ class Client {
     try {
       new _url.URL(env);
     } catch (err) {
-      throw new Error(`Expected env to start with https:// but got ${env}. Try passing in stytch.envs.test or stytch.envs.live instead.`);
+      throw new Error(`Expected the Stytch client's env to start with https:// but received "${env}". Try passing in stytch.envs.test or stytch.envs.live instead.`);
     }
 
     console.warn(`[STYTCH]: Connecting to non-default Stytch API instance: ${env}`);

--- a/dist/client.js
+++ b/dist/client.js
@@ -7,6 +7,8 @@ exports.Client = void 0;
 
 var _axios = _interopRequireDefault(require("axios"));
 
+var _url = require("url");
+
 var _package = require("../package.json");
 
 var envs = _interopRequireWildcard(require("./envs"));
@@ -47,9 +49,7 @@ class Client {
       throw new Error('Missing "env" in config');
     }
 
-    if (config.env != envs.test && config.env != envs.live) {// TODO: warn about non-production configuration
-    }
-
+    Client.validateStytchEnvironment(config.env);
     this.client = _axios.default.create({
       baseURL: config.env,
       timeout: config.timeout || DEFAULT_TIMEOUT,
@@ -157,6 +157,20 @@ class Client {
 
   authenticateOTP(data) {
     return this.otps.authenticate(data);
+  }
+
+  static validateStytchEnvironment(env) {
+    if (env === envs.test || env === envs.live) {
+      return;
+    }
+
+    try {
+      new _url.URL(env);
+    } catch (err) {
+      throw new Error(`Expected env to start with https:// but got ${env}. Try passing in stytch.envs.test or stytch.envs.live instead.`);
+    }
+
+    console.warn(`[STYTCH]: Connecting to non-default Stytch API instance: ${env}`);
   }
 
 }

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -1,4 +1,5 @@
 import axios from "axios";
+import { URL } from "url";
 import { version } from "../package.json";
 import * as envs from "./envs";
 import { Users } from "./users";
@@ -48,9 +49,7 @@ export class Client {
       throw new Error('Missing "env" in config');
     }
 
-    if (config.env != envs.test && config.env != envs.live) {
-      // TODO: warn about non-production configuration
-    }
+    Client.validateStytchEnvironment(config.env);
 
     this.client = axios.create({
       baseURL: config.env,
@@ -169,5 +168,17 @@ export class Client {
     data: otps.AuthenticateRequest
   ): Promise<otps.AuthenticateResponse> {
     return this.otps.authenticate(data);
+  }
+
+  private static validateStytchEnvironment(env: string): void {
+    if (env === envs.test || env === envs.live) {
+      return;
+    }
+    try {
+      new URL(env);
+    } catch(err) {
+      throw new Error(`Expected env to start with https:// but got ${env}. Try passing in stytch.envs.test or stytch.envs.live instead.`);
+    }
+    console.warn(`[STYTCH]: Connecting to non-default Stytch API instance: ${env}`);
   }
 }

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -178,7 +178,7 @@ export class Client {
       new URL(env);
     } catch (err) {
       throw new Error(
-        `Expected env to start with https:// but got ${env}. Try passing in stytch.envs.test or stytch.envs.live instead.`
+        `Expected the Stytch client's env to start with https:// but received "${env}". Try passing in stytch.envs.test or stytch.envs.live instead.`
       );
     }
     console.warn(

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -176,9 +176,13 @@ export class Client {
     }
     try {
       new URL(env);
-    } catch(err) {
-      throw new Error(`Expected env to start with https:// but got ${env}. Try passing in stytch.envs.test or stytch.envs.live instead.`);
+    } catch (err) {
+      throw new Error(
+        `Expected env to start with https:// but got ${env}. Try passing in stytch.envs.test or stytch.envs.live instead.`
+      );
     }
-    console.warn(`[STYTCH]: Connecting to non-default Stytch API instance: ${env}`);
+    console.warn(
+      `[STYTCH]: Connecting to non-default Stytch API instance: ${env}`
+    );
   }
 }

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -54,7 +54,7 @@ describe("config validation", () => {
         secret: "secret-test-11111111-1111-4111-8111-111111111111",
         env: "some bad env",
       });
-    }).toThrow(/Expected env to start with https:\/\/ but got some bad env. Try passing in stytch.envs.test or stytch.envs.live instead./);
+    }).toThrow(/Expected the Stytch client's env to start with https:\/\/ but received "${env}". Try passing in stytch.envs.test or stytch.envs.live instead./);
   });
 });
 

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -1,6 +1,16 @@
 import * as stytch from "../lib";
 
-describe("config errors", () => {
+describe("config validation", () => {
+  test("does not throw when everything is valid", () => {
+    expect(() => {
+      new stytch.Client({
+        project_id: "project-test-00000000-0000-4000-8000-000000000000",
+        secret: "secret-test-11111111-1111-4111-8111-111111111111",
+        env: stytch.envs.test,
+      });
+    }).not.toThrow();
+  });
+
   test("config is not an object", () => {
     expect(() => {
       new stytch.Client(0 as any); // eslint-disable-line @typescript-eslint/no-explicit-any
@@ -35,6 +45,16 @@ describe("config errors", () => {
         env: "",
       });
     }).toThrow(/Missing "env" in config/);
+  });
+
+  test("Invalid HTTPS url for environment", () => {
+    expect(() => {
+      new stytch.Client({
+        project_id: "project-test-00000000-0000-4000-8000-000000000000",
+        secret: "secret-test-11111111-1111-4111-8111-111111111111",
+        env: "some bad env",
+      });
+    }).toThrow(/Expected env to start with https:\/\/ but got some bad env. Try passing in stytch.envs.test or stytch.envs.live instead./);
   });
 });
 

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -54,7 +54,7 @@ describe("config validation", () => {
         secret: "secret-test-11111111-1111-4111-8111-111111111111",
         env: "some bad env",
       });
-    }).toThrow(/Expected the Stytch client's env to start with https:\/\/ but received "${env}". Try passing in stytch.envs.test or stytch.envs.live instead./);
+    }).toThrow(/Expected the Stytch client's env to start with https:\/\/ but received "some bad env". Try passing in stytch.envs.test or stytch.envs.live instead./);
   });
 });
 

--- a/types/lib/client.d.ts
+++ b/types/lib/client.d.ts
@@ -50,5 +50,6 @@ export declare class Client {
     loginOrCreateUserBySMS(data: otps.LoginOrCreateUserBySMSRequest): Promise<otps.LoginOrCreateUserBySMSResponse>;
     /** @deprecated since version 3.0. Will be deleted in version 4.0.  Use otps.authenticate instead. */
     authenticateOTP(data: otps.AuthenticateRequest): Promise<otps.AuthenticateResponse>;
+    private static validateStytchEnvironment;
 }
 export {};


### PR DESCRIPTION
When Axios is given a baseURL that is not a valid URL, it attempts to connect to Localhost instead. We should catch that and throw an informative error explaining what is expected. We should also log a warning if a non-default URL is passed in.
```nodejs
> require('axios').get('not-a-url')
> (node:34515) UnhandledPromiseRejectionWarning: Error: connect ECONNREFUSED 127.0.0.1:80
    at TCPConnectWrap.afterConnect [as oncomplete] (net.js:1148:16)
    at TCPConnectWrap.callbackTrampoline (internal/async_hooks.js:131:17)
```