### PR TITLE
feat: Add last_authenticated_at timestamp to authentication factors

### DIFF
--- a/lib/shared.ts
+++ b/lib/shared.ts
@@ -28,6 +28,7 @@ export interface PhoneNumber {
 export interface EmailFactor {
   delivery_method: "email" | "embedded";
   type: string;
+  last_authenticated_at: Date;
   email_factor: {
     email_id: string;
     email_address: string;
@@ -37,6 +38,7 @@ export interface EmailFactor {
 export interface PhoneNumberFactor {
   delivery_method: "sms" | "whatsapp";
   type: string;
+  last_authenticated_at: Date;
   phone_number_factor: {
     phone_id: string;
     phone_number: string;
@@ -46,6 +48,7 @@ export interface PhoneNumberFactor {
 export interface GoogleOAuthFactor {
   delivery_method: "oauth_google";
   type: string;
+  last_authenticated_at: string;
   google_oauth_factor: {
     id: string;
     email_id: string;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stytch",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "stytch",
-      "version": "3.5.0",
+      "version": "3.5.1",
       "license": "MIT",
       "dependencies": {
         "axios": "^0.21.4"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stytch",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "description": "A wrapper for the Stytch API",
   "types": "./types/lib/index.d.ts",
   "main": "./dist/index.js",

--- a/types/lib/shared.d.ts
+++ b/types/lib/shared.d.ts
@@ -21,6 +21,7 @@ export interface PhoneNumber {
 export interface EmailFactor {
     delivery_method: "email" | "embedded";
     type: string;
+    last_authenticated_at: Date;
     email_factor: {
         email_id: string;
         email_address: string;
@@ -29,6 +30,7 @@ export interface EmailFactor {
 export interface PhoneNumberFactor {
     delivery_method: "sms" | "whatsapp";
     type: string;
+    last_authenticated_at: Date;
     phone_number_factor: {
         phone_id: string;
         phone_number: string;
@@ -37,6 +39,7 @@ export interface PhoneNumberFactor {
 export interface GoogleOAuthFactor {
     delivery_method: "oauth_google";
     type: string;
+    last_authenticated_at: string;
     google_oauth_factor: {
         id: string;
         email_id: string;


### PR DESCRIPTION
Expose the newly-added `last_authenticated_at` timestamp on sessions authentication factors.

I tested this by sending myself a magic link and verifying that `client.magicLinks.authenticate` (with `sessionDurationMinutes` set) returns the right timestamp on `res.session.authenticationFactors[0]`.
