### PR TITLE
fix: Update Factor typedefs to match API response

### DIFF
--- a/lib/shared.ts
+++ b/lib/shared.ts
@@ -45,7 +45,7 @@ export interface OAuthProvider {
 export interface EmailFactor {
   delivery_method: "email" | "embedded";
   type: string;
-  last_authenticated_at: Date;
+  last_authenticated_at: string;
   email_factor: {
     email_id: string;
     email_address: string;
@@ -55,7 +55,7 @@ export interface EmailFactor {
 export interface PhoneNumberFactor {
   delivery_method: "sms" | "whatsapp";
   type: string;
-  last_authenticated_at: Date;
+  last_authenticated_at: string;
   phone_number_factor: {
     phone_id: string;
     phone_number: string;
@@ -77,7 +77,7 @@ export interface MicrosoftOAuthFactor {
   delivery_method: "oauth_microsoft";
   type: string;
   last_authenticated_at: string;
-  google_oauth_factor: {
+  microsoft_oauth_factor: {
     id: string;
     email_id: string;
     provider_subject: string;
@@ -88,7 +88,7 @@ export interface AppleOAuthFactor {
   delivery_method: "oauth_apple";
   type: string;
   last_authenticated_at: string;
-  google_oauth_factor: {
+  apple_oauth_factor: {
     id: string;
     email_id: string;
     provider_subject: string;
@@ -99,7 +99,7 @@ export interface GithubOAuthFactor {
   delivery_method: "oauth_github";
   type: string;
   last_authenticated_at: string;
-  google_oauth_factor: {
+  github_oauth_factor: {
     id: string;
     email_id: string;
     provider_subject: string;
@@ -109,7 +109,7 @@ export interface GithubOAuthFactor {
 export interface WebAuthnFactor {
   delivery_method: "webauthn_registration";
   type: string;
-  last_authenticated_at: Date;
+  last_authenticated_at: string;
   webauthn_factor: {
     webauthn_registration_id: string;
     domain: string;
@@ -120,7 +120,7 @@ export interface WebAuthnFactor {
 export interface AuthenticatorAppFactor {
   delivery_method: "authenticator_app";
   type: string;
-  last_authenticated_at: Date;
+  last_authenticated_at: string;
   authenticator_app_factor: {
     totp_id: string;
   };
@@ -129,7 +129,7 @@ export interface AuthenticatorAppFactor {
 export interface RecoveryCodeFactor {
   delivery_method: "recovery_code";
   type: string;
-  last_authenticated_at: Date;
+  last_authenticated_at: string;
   recovery_code_factor: {
     totp_recovery_code_id: string;
   };
@@ -143,7 +143,8 @@ export type AuthenticationFactor =
   | AppleOAuthFactor
   | GithubOAuthFactor
   | WebAuthnFactor
-  | AuthenticatorAppFactor;
+  | AuthenticatorAppFactor
+  | RecoveryCodeFactor;
 
 export interface Session {
   session_id: string;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "stytch",
-  "version": "3.10.1",
+  "version": "3.10.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stytch",
-  "version": "3.10.1",
+  "version": "3.10.2",
   "description": "A wrapper for the Stytch API",
   "types": "./types/lib/index.d.ts",
   "main": "./dist/index.js",

--- a/types/lib/shared.d.ts
+++ b/types/lib/shared.d.ts
@@ -35,7 +35,7 @@ export interface OAuthProvider {
 export interface EmailFactor {
     delivery_method: "email" | "embedded";
     type: string;
-    last_authenticated_at: Date;
+    last_authenticated_at: string;
     email_factor: {
         email_id: string;
         email_address: string;
@@ -44,7 +44,7 @@ export interface EmailFactor {
 export interface PhoneNumberFactor {
     delivery_method: "sms" | "whatsapp";
     type: string;
-    last_authenticated_at: Date;
+    last_authenticated_at: string;
     phone_number_factor: {
         phone_id: string;
         phone_number: string;
@@ -64,7 +64,7 @@ export interface MicrosoftOAuthFactor {
     delivery_method: "oauth_microsoft";
     type: string;
     last_authenticated_at: string;
-    google_oauth_factor: {
+    microsoft_oauth_factor: {
         id: string;
         email_id: string;
         provider_subject: string;
@@ -74,7 +74,7 @@ export interface AppleOAuthFactor {
     delivery_method: "oauth_apple";
     type: string;
     last_authenticated_at: string;
-    google_oauth_factor: {
+    apple_oauth_factor: {
         id: string;
         email_id: string;
         provider_subject: string;
@@ -84,7 +84,7 @@ export interface GithubOAuthFactor {
     delivery_method: "oauth_github";
     type: string;
     last_authenticated_at: string;
-    google_oauth_factor: {
+    github_oauth_factor: {
         id: string;
         email_id: string;
         provider_subject: string;
@@ -93,7 +93,7 @@ export interface GithubOAuthFactor {
 export interface WebAuthnFactor {
     delivery_method: "webauthn_registration";
     type: string;
-    last_authenticated_at: Date;
+    last_authenticated_at: string;
     webauthn_factor: {
         webauthn_registration_id: string;
         domain: string;
@@ -103,7 +103,7 @@ export interface WebAuthnFactor {
 export interface AuthenticatorAppFactor {
     delivery_method: "authenticator_app";
     type: string;
-    last_authenticated_at: Date;
+    last_authenticated_at: string;
     authenticator_app_factor: {
         totp_id: string;
     };
@@ -111,12 +111,12 @@ export interface AuthenticatorAppFactor {
 export interface RecoveryCodeFactor {
     delivery_method: "recovery_code";
     type: string;
-    last_authenticated_at: Date;
+    last_authenticated_at: string;
     recovery_code_factor: {
         totp_recovery_code_id: string;
     };
 }
-export declare type AuthenticationFactor = EmailFactor | PhoneNumberFactor | GoogleOAuthFactor | MicrosoftOAuthFactor | AppleOAuthFactor | GithubOAuthFactor | WebAuthnFactor | AuthenticatorAppFactor;
+export declare type AuthenticationFactor = EmailFactor | PhoneNumberFactor | GoogleOAuthFactor | MicrosoftOAuthFactor | AppleOAuthFactor | GithubOAuthFactor | WebAuthnFactor | AuthenticatorAppFactor | RecoveryCodeFactor;
 export interface Session {
     session_id: string;
     user_id: string;


### PR DESCRIPTION
- Updates various OAuth factors to have correctly-named props
- Updates the `factor.last_authenticated_at` field to be a string (since we never parse it as a date)
- Adds `RecoveryCodeFactor` to the `AuthenticationFactor` sum type so callers can check it without needing to cast