### PR TITLE
Add stytch_session to oauth AuthenticateResponse

### DIFF
--- a/lib/oauth.ts
+++ b/lib/oauth.ts
@@ -1,5 +1,5 @@
 import type { AxiosInstance } from "axios";
-import type { BaseResponse } from "./shared";
+import type { BaseResponse, Session } from "./shared";
 import { request } from "./shared";
 
 export interface AuthenticateRequest {
@@ -12,6 +12,10 @@ export interface OAuthSession {
   idp?: {
     access_token?: string;
     refresh_token?: string;
+  };
+  stytch_session?: {
+    session: Session;
+    session_token: string;
   };
 }
 

--- a/types/lib/oauth.d.ts
+++ b/types/lib/oauth.d.ts
@@ -1,5 +1,5 @@
 import type { AxiosInstance } from "axios";
-import type { BaseResponse } from "./shared";
+import type { BaseResponse, Session } from "./shared";
 export interface AuthenticateRequest {
     session_management_type?: "stytch" | "idp" | "none";
     session_token?: string;
@@ -9,6 +9,10 @@ export interface OAuthSession {
     idp?: {
         access_token?: string;
         refresh_token?: string;
+    };
+    stytch_session?: {
+        session: Session;
+        session_token: string;
     };
 }
 export interface AuthenticateResponse extends BaseResponse {


### PR DESCRIPTION
The `OAuthSession` interface is currently missing `stytch_session` meaning that setting `session_management_type: "stytch"` does not return a session token. This PR fixes this by adding the proper types to the client.

See discussion in: https://stytch.slack.com/archives/C015UDB4X33/p1645050233365429