### PR TITLE
Include authenticator_type in registration interface

### DIFF
--- a/lib/shared.ts
+++ b/lib/shared.ts
@@ -34,6 +34,7 @@ export interface WebAuthnRegistration {
   domain: string;
   user_agent: string;
   verified: boolean;
+  authenticator_type: string;
 }
 
 export interface TOTP {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stytch",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "stytch",
-      "version": "5.0.0",
+      "version": "5.0.1",
       "license": "MIT",
       "dependencies": {
         "isomorphic-base64": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stytch",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "A wrapper for the Stytch API",
   "types": "./types/lib/index.d.ts",
   "main": "./dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,6 @@
 {
   "name": "stytch",
-<<<<<<< HEAD
-  "version": "5.0.1",
-=======
-  "version": "5.1.0",
->>>>>>> main
+  "version": "5.1.1",
   "description": "A wrapper for the Stytch API",
   "types": "./types/lib/index.d.ts",
   "main": "./dist/index.js",

--- a/types/lib/shared.d.ts
+++ b/types/lib/shared.d.ts
@@ -24,6 +24,7 @@ export interface WebAuthnRegistration {
     domain: string;
     user_agent: string;
     verified: boolean;
+    authenticator_type: string;
 }
 export interface TOTP {
     totp_id: string;


### PR DESCRIPTION
Ran `npm run build`. Also assuming we bump minor version for a change like this.