### PR TITLE
fix: Prefer session.expires_at value in session JWT claims

### DIFF
--- a/dist/sessions.js
+++ b/dist/sessions.js
@@ -145,10 +145,11 @@ class Sessions {
       user_id: payload.sub || "",
       // Parse the timestamps into Dates. The JWT expiration time is the same as the session's.
       // The exp claim is a Unix timestamp in seconds, so convert it to milliseconds first. The
-      // other two timestamps are RFC3339-formatted strings.
+      // other timestamps are RFC3339-formatted strings.
       started_at: new Date(claim.started_at),
       last_accessed_at: new Date(claim.last_accessed_at),
-      expires_at: new Date((payload.exp || 0) * 1000)
+      // For JWTs that include it, prefer the inner expires_at claim.
+      expires_at: new Date(claim.expires_at || (payload.exp || 0) * 1000)
     };
   }
 

--- a/lib/sessions.ts
+++ b/lib/sessions.ts
@@ -235,10 +235,11 @@ export class Sessions {
 
       // Parse the timestamps into Dates. The JWT expiration time is the same as the session's.
       // The exp claim is a Unix timestamp in seconds, so convert it to milliseconds first. The
-      // other two timestamps are RFC3339-formatted strings.
+      // other timestamps are RFC3339-formatted strings.
       started_at: new Date(claim.started_at),
       last_accessed_at: new Date(claim.last_accessed_at),
-      expires_at: new Date((payload.exp || 0) * 1000),
+      // For JWTs that include it, prefer the inner expires_at claim.
+      expires_at: new Date(claim.expires_at || (payload.exp || 0) * 1000),
     };
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stytch",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "description": "A wrapper for the Stytch API",
   "types": "./types/lib/index.d.ts",
   "main": "./dist/index.js",


### PR DESCRIPTION
Stytch session JWTs now include the session's `expires_at` value within the session data claim. If
present, prefer using that value to determine the session's expiration. For backward compatibility
with old tokens that don't include it, continue using the value from the "exp" claim.
