### PR TITLE
 feat: Add a user object to all authenticate and update calls

### DIFF
--- a/dist/crypto_wallets.js
+++ b/dist/crypto_wallets.js
@@ -31,6 +31,10 @@ class CryptoWallets {
       method: "POST",
       url: this.endpoint("authenticate"),
       data
+    }).then(res => {
+      return { ...res,
+        user: (0, _shared.parseUser)(res.user)
+      };
     });
   }
 

--- a/dist/magic_links.js
+++ b/dist/magic_links.js
@@ -82,6 +82,10 @@ class MagicLinks {
         token,
         ...data
       }
+    }).then(res => {
+      return { ...res,
+        user: (0, _shared.parseUser)(res.user)
+      };
     });
   }
 

--- a/dist/oauth.js
+++ b/dist/oauth.js
@@ -26,6 +26,10 @@ class OAuth {
         token,
         ...data
       }
+    }).then(res => {
+      return { ...res,
+        user: (0, _shared.parseUser)(res.user)
+      };
     });
   }
 

--- a/dist/otps.js
+++ b/dist/otps.js
@@ -116,6 +116,10 @@ class OTPs {
       method: "POST",
       url: this.endpoint("authenticate"),
       data
+    }).then(res => {
+      return { ...res,
+        user: (0, _shared.parseUser)(res.user)
+      };
     });
   }
 

--- a/dist/sessions.js
+++ b/dist/sessions.js
@@ -61,6 +61,7 @@ class Sessions {
       data
     }).then(res => {
       return { ...res,
+        user: (0, _shared.parseUser)(res.user),
         session: parseSession(res.session)
       };
     });

--- a/dist/shared.js
+++ b/dist/shared.js
@@ -4,6 +4,7 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports.request = request;
+exports.parseUser = parseUser;
 
 var _errors = require("./errors");
 
@@ -50,4 +51,10 @@ async function request(fetchConfig, requestConfig) {
   }
 
   return responseJSON;
+}
+
+function parseUser(user) {
+  return { ...user,
+    created_at: new Date(user.created_at)
+  };
 }

--- a/dist/totps.js
+++ b/dist/totps.js
@@ -31,6 +31,10 @@ class TOTPs {
       method: "POST",
       url: this.endpoint("authenticate"),
       data
+    }).then(res => {
+      return { ...res,
+        user: (0, _shared.parseUser)(res.user)
+      };
     });
   }
 
@@ -47,6 +51,10 @@ class TOTPs {
       method: "POST",
       url: this.endpoint("recover"),
       data
+    }).then(res => {
+      return { ...res,
+        user: (0, _shared.parseUser)(res.user)
+      };
     });
   }
 

--- a/dist/users.js
+++ b/dist/users.js
@@ -75,6 +75,10 @@ class Users {
       method: "POST",
       url: this.base_path,
       data
+    }).then(res => {
+      return { ...res,
+        user: (0, _shared.parseUser)(res.user)
+      };
     });
   }
 
@@ -83,7 +87,7 @@ class Users {
       method: "GET",
       url: this.endpoint(userID)
     }).then(res => ({ ...res,
-      ...parseUser(res)
+      ...(0, _shared.parseUser)(res)
     }));
   }
 
@@ -94,7 +98,7 @@ class Users {
       data
     }).then(res => {
       return { ...res,
-        results: res.results.map(parseUser)
+        results: res.results.map(_shared.parseUser)
       };
     });
   }
@@ -108,6 +112,10 @@ class Users {
       method: "PUT",
       url: this.endpoint(userID),
       data
+    }).then(res => {
+      return { ...res,
+        user: (0, _shared.parseUser)(res.user)
+      };
     });
   }
 
@@ -131,6 +139,10 @@ class Users {
     return (0, _shared.request)(this.fetchConfig, {
       method: "DELETE",
       url: this.endpoint(`emails/${emailID}`)
+    }).then(res => {
+      return { ...res,
+        user: (0, _shared.parseUser)(res.user)
+      };
     });
   }
 
@@ -138,6 +150,10 @@ class Users {
     return (0, _shared.request)(this.fetchConfig, {
       method: "DELETE",
       url: this.endpoint(`phone_numbers/${phoneID}`)
+    }).then(res => {
+      return { ...res,
+        user: (0, _shared.parseUser)(res.user)
+      };
     });
   }
 
@@ -145,6 +161,10 @@ class Users {
     return (0, _shared.request)(this.fetchConfig, {
       method: "DELETE",
       url: this.endpoint(`webauthn_registrations/${webAuthnRegistrationID}`)
+    }).then(res => {
+      return { ...res,
+        user: (0, _shared.parseUser)(res.user)
+      };
     });
   }
 
@@ -152,6 +172,10 @@ class Users {
     return (0, _shared.request)(this.fetchConfig, {
       method: "DELETE",
       url: this.endpoint(`totps/${totpID}`)
+    }).then(res => {
+      return { ...res,
+        user: (0, _shared.parseUser)(res.user)
+      };
     });
   }
 
@@ -159,15 +183,13 @@ class Users {
     return (0, _shared.request)(this.fetchConfig, {
       method: "DELETE",
       url: this.endpoint(`crypto_wallets/${cryptoWalletID}`)
+    }).then(res => {
+      return { ...res,
+        user: (0, _shared.parseUser)(res.user)
+      };
     });
   }
 
 }
 
 exports.Users = Users;
-
-function parseUser(user) {
-  return { ...user,
-    created_at: new Date(user.created_at)
-  };
-}

--- a/dist/webauthn.js
+++ b/dist/webauthn.js
@@ -47,6 +47,10 @@ class WebAuthn {
       method: "POST",
       url: this.endpoint("authenticate"),
       data
+    }).then(res => {
+      return { ...res,
+        user: (0, _shared.parseUser)(res.user)
+      };
     });
   }
 

--- a/lib/__mocks__/shared.ts
+++ b/lib/__mocks__/shared.ts
@@ -3,7 +3,7 @@ import { User, UserRaw } from "../shared";
 export const request = jest.fn();
 
 export function parseUser(user: UserRaw): User {
-  if(typeof user !== "object") {
+  if (typeof user !== "object") {
     return user;
   }
   return {

--- a/lib/__mocks__/shared.ts
+++ b/lib/__mocks__/shared.ts
@@ -1,1 +1,13 @@
+import { User, UserRaw } from "../shared";
+
 export const request = jest.fn();
+
+export function parseUser(user: UserRaw): User {
+  if(typeof user !== "object") {
+    return user;
+  }
+  return {
+    ...user,
+    created_at: new Date(user.created_at),
+  };
+}

--- a/lib/crypto_wallets.ts
+++ b/lib/crypto_wallets.ts
@@ -1,4 +1,11 @@
-import { request, Session, fetchConfig, parseUser, WithRawUser, User } from "./shared";
+import {
+  request,
+  Session,
+  fetchConfig,
+  parseUser,
+  WithRawUser,
+  User,
+} from "./shared";
 
 import type { BaseResponse } from "./shared";
 import { UserID } from "./users";
@@ -45,7 +52,7 @@ export class CryptoWallets {
   }
 
   authenticateStart(
-    data: AuthenticateStartRequest,
+    data: AuthenticateStartRequest
   ): Promise<AuthenticateStartResponse> {
     return request(this.fetchConfig, {
       method: "POST",

--- a/lib/crypto_wallets.ts
+++ b/lib/crypto_wallets.ts
@@ -1,4 +1,4 @@
-import { request, Session, fetchConfig } from "./shared";
+import { request, Session, fetchConfig, parseUser, WithRawUser, User } from "./shared";
 
 import type { BaseResponse } from "./shared";
 import { UserID } from "./users";
@@ -26,6 +26,7 @@ export interface AuthenticateRequest {
 
 export interface AuthenticateResponse extends BaseResponse {
   user_id: UserID;
+  user: User;
   session_token?: string;
   session_jwt?: string;
   session?: Session;
@@ -44,7 +45,7 @@ export class CryptoWallets {
   }
 
   authenticateStart(
-    data: AuthenticateStartRequest
+    data: AuthenticateStartRequest,
   ): Promise<AuthenticateStartResponse> {
     return request(this.fetchConfig, {
       method: "POST",
@@ -54,10 +55,15 @@ export class CryptoWallets {
   }
 
   authenticate(data: AuthenticateRequest): Promise<AuthenticateResponse> {
-    return request(this.fetchConfig, {
+    return request<WithRawUser<AuthenticateResponse>>(this.fetchConfig, {
       method: "POST",
       url: this.endpoint("authenticate"),
       data,
+    }).then((res) => {
+      return {
+        ...res,
+        user: parseUser(res.user),
+      };
     });
   }
 }

--- a/lib/magic_links.ts
+++ b/lib/magic_links.ts
@@ -1,4 +1,4 @@
-import { request, Session } from "./shared";
+import { parseUser, request, Session, User, WithRawUser } from "./shared";
 
 import type { Attributes, BaseResponse, Name, fetchConfig } from "./shared";
 
@@ -69,6 +69,7 @@ export interface AuthenticateRequest {
 
 export interface AuthenticateResponse extends BaseResponse {
   user_id: string;
+  user: User;
   method_id: string;
   session_token?: string;
   session_jwt?: string;
@@ -160,10 +161,15 @@ export class MagicLinks {
     token: string,
     data?: AuthenticateRequest
   ): Promise<AuthenticateResponse> {
-    return request(this.fetchConfig, {
+    return request<WithRawUser<AuthenticateResponse>>(this.fetchConfig, {
       method: "POST",
       url: this.endpoint("authenticate"),
       data: { token, ...data },
+    }).then((res) => {
+      return {
+        ...res,
+        user: parseUser(res.user),
+      };
     });
   }
 }

--- a/lib/oauth.ts
+++ b/lib/oauth.ts
@@ -1,5 +1,5 @@
-import type { BaseResponse, Session, fetchConfig } from "./shared";
-import { request } from "./shared";
+import type { BaseResponse, Session, fetchConfig, WithRawUser, User } from "./shared";
+import { parseUser, request } from "./shared";
 
 export interface AuthenticateRequest {
   session_token?: string;
@@ -9,6 +9,7 @@ export interface AuthenticateRequest {
 
 export interface AuthenticateResponse extends BaseResponse {
   user_id: string;
+  user: User;
   provider_subject: string;
   provider_type: string;
   session_token?: string;
@@ -42,10 +43,15 @@ export class OAuth {
     token: string,
     data?: AuthenticateRequest
   ): Promise<AuthenticateResponse> {
-    return request(this.fetchConfig, {
+    return request<WithRawUser<AuthenticateResponse>>(this.fetchConfig, {
       method: "POST",
       url: this.endpoint("authenticate"),
       data: { token, ...data },
+    }).then((res) => {
+      return {
+        ...res,
+        user: parseUser(res.user),
+      };
     });
   }
 }

--- a/lib/oauth.ts
+++ b/lib/oauth.ts
@@ -1,4 +1,10 @@
-import type { BaseResponse, Session, fetchConfig, WithRawUser, User } from "./shared";
+import type {
+  BaseResponse,
+  Session,
+  fetchConfig,
+  WithRawUser,
+  User,
+} from "./shared";
 import { parseUser, request } from "./shared";
 
 export interface AuthenticateRequest {

--- a/lib/otps.ts
+++ b/lib/otps.ts
@@ -1,4 +1,4 @@
-import { fetchConfig, request } from "./shared";
+import { fetchConfig, parseUser, request, User, WithRawUser } from "./shared";
 
 import type { Attributes, BaseResponse, Session } from "./shared";
 
@@ -89,6 +89,7 @@ export interface AuthenticateRequest {
 
 export interface AuthenticateResponse extends BaseResponse {
   user_id: string;
+  user: User;
   method_id: string;
   session_token?: string;
   session_jwt?: string;
@@ -217,10 +218,15 @@ export class OTPs {
   }
 
   authenticate(data: AuthenticateRequest): Promise<AuthenticateResponse> {
-    return request(this.fetchConfig, {
+    return request<WithRawUser<AuthenticateResponse>>(this.fetchConfig, {
       method: "POST",
       url: this.endpoint("authenticate"),
       data,
+    }).then((res) => {
+      return {
+        ...res,
+        user: parseUser(res.user),
+      };
     });
   }
 }

--- a/lib/sessions.ts
+++ b/lib/sessions.ts
@@ -4,7 +4,7 @@ import {
   Attributes,
   Session,
   AuthenticationFactor,
-  fetchConfig,
+  fetchConfig, parseUser, WithRawUser, User,
 } from "./shared";
 import { ClientError } from "./errors";
 
@@ -43,6 +43,7 @@ export interface AuthenticateRequest {
 
 export interface AuthenticateResponse extends BaseResponse {
   session: Session;
+  user: User;
   session_token: string;
   session_jwt: string;
 }
@@ -70,6 +71,7 @@ interface GetResponseRaw extends BaseResponse {
 }
 
 interface AuthenticateResponseRaw extends BaseResponse {
+  user: User;
   session: SessionRaw;
   session_token: string;
   session_jwt: string;
@@ -134,13 +136,14 @@ export class Sessions {
   }
 
   authenticate(data: AuthenticateRequest): Promise<AuthenticateResponse> {
-    return request<AuthenticateResponseRaw>(this.fetchConfig, {
+    return request<WithRawUser<AuthenticateResponseRaw>>(this.fetchConfig, {
       method: "POST",
       url: this.endpoint("authenticate"),
       data,
     }).then((res): AuthenticateResponse => {
       return {
         ...res,
+        user: parseUser(res.user),
         session: parseSession(res.session),
       };
     });

--- a/lib/sessions.ts
+++ b/lib/sessions.ts
@@ -4,7 +4,10 @@ import {
   Attributes,
   Session,
   AuthenticationFactor,
-  fetchConfig, parseUser, WithRawUser, User,
+  fetchConfig,
+  parseUser,
+  WithRawUser,
+  User,
 } from "./shared";
 import { ClientError } from "./errors";
 

--- a/lib/shared.ts
+++ b/lib/shared.ts
@@ -242,12 +242,12 @@ export type requestConfig = {
 
 export async function request<T>(
   fetchConfig: fetchConfig,
-  requestConfig: requestConfig,
+  requestConfig: requestConfig
 ): Promise<T> {
   const url = new URL(requestConfig.url, fetchConfig.baseURL);
   if (requestConfig.params) {
     Object.entries(requestConfig.params).forEach(([key, value]) =>
-      url.searchParams.append(key, String(value)),
+      url.searchParams.append(key, String(value))
     );
   }
 
@@ -270,7 +270,7 @@ export async function request<T>(
     const err = e as Error;
     throw new RequestError(
       `Unable to parse JSON response from server: ${err.message}`,
-      requestConfig,
+      requestConfig
     );
   }
 
@@ -282,7 +282,9 @@ export async function request<T>(
 }
 
 export type UserRaw = Omit<User, "created_at"> & { created_at: string };
-export type WithRawUser<T extends { "user": User }> = Omit<T, "user"> & { user: UserRaw }
+export type WithRawUser<T extends { user: User }> = Omit<T, "user"> & {
+  user: UserRaw;
+};
 
 export function parseUser(user: UserRaw): User {
   return {

--- a/lib/totps.ts
+++ b/lib/totps.ts
@@ -1,4 +1,4 @@
-import { request } from "./shared";
+import { parseUser, request, User, WithRawUser } from "./shared";
 
 import type { BaseResponse, Session, fetchConfig } from "./shared";
 
@@ -30,6 +30,7 @@ export interface AuthenticateRequest {
 
 export interface AuthenticateResponse extends BaseResponse {
   user_id: string;
+  user: User;
   totp_id: string;
   session_token?: string;
   session_jwt?: string;
@@ -55,6 +56,7 @@ export interface RecoverRequest {
 
 export interface RecoverResponse extends BaseResponse {
   user_id: string;
+  user: User;
   totp_id: string;
   session_token?: string;
   session_jwt?: string;
@@ -83,10 +85,15 @@ export class TOTPs {
   }
 
   authenticate(data: AuthenticateRequest): Promise<AuthenticateResponse> {
-    return request(this.fetchConfig, {
+    return request<WithRawUser<AuthenticateResponse>>(this.fetchConfig, {
       method: "POST",
       url: this.endpoint("authenticate"),
       data,
+    }).then((res) => {
+      return {
+        ...res,
+        user: parseUser(res.user),
+      };
     });
   }
 
@@ -99,10 +106,15 @@ export class TOTPs {
   }
 
   recover(data: RecoverRequest): Promise<RecoverResponse> {
-    return request(this.fetchConfig, {
+    return request<WithRawUser<RecoverResponse>>(this.fetchConfig, {
       method: "POST",
       url: this.endpoint("recover"),
       data,
+    }).then((res) => {
+      return {
+        ...res,
+        user: parseUser(res.user),
+      };
     });
   }
 }

--- a/lib/users.ts
+++ b/lib/users.ts
@@ -1,4 +1,4 @@
-import { OAuthProvider, request } from "./shared";
+import { parseUser, request, User, UserRaw, WithRawUser } from "./shared";
 
 import type {
   Attributes,
@@ -6,7 +6,6 @@ import type {
   Email,
   Name,
   PhoneNumber,
-  WebAuthnRegistration,
   TOTP,
   CryptoWallet,
   fetchConfig,
@@ -35,25 +34,11 @@ export interface CreateRequest {
 
 export interface CreateResponse extends BaseResponse {
   user_id: UserID;
+  user: User;
   email_id: string;
   phone_id: string;
   status: string;
 }
-
-interface User {
-  user_id: UserID;
-  created_at: Date;
-  status: string;
-  name: Name;
-  emails: Email[];
-  phone_numbers: PhoneNumber[];
-  providers: OAuthProvider[];
-  webauthn_registrations: WebAuthnRegistration[];
-  totps: TOTP[];
-  crypto_wallets: CryptoWallet[];
-}
-
-type UserRaw = Omit<User, "created_at"> & { created_at: string };
 
 export type GetResponse = BaseResponse & User;
 
@@ -64,100 +49,100 @@ export enum UserSearchOperator {
 
 export type UserSearchOperand =
   | {
-      filter_name: "created_at_greater_than";
-      // Timestamp in RFC 3339 Format
-      filter_value: string;
-    }
+  filter_name: "created_at_greater_than";
+  // Timestamp in RFC 3339 Format
+  filter_value: string;
+}
   | {
-      filter_name: "created_at_less_than";
-      // Timestamp in RFC 3339 Format
-      filter_value: string;
-    }
+  filter_name: "created_at_less_than";
+  // Timestamp in RFC 3339 Format
+  filter_value: string;
+}
   | {
-      filter_name: "created_at_between";
-      filter_value: {
-        // Timestamp in RFC 3339 Format
-        greater_than: string;
-        // Timestamp in RFC 3339 Format
-        less_than: string;
-      };
-    }
+  filter_name: "created_at_between";
+  filter_value: {
+    // Timestamp in RFC 3339 Format
+    greater_than: string;
+    // Timestamp in RFC 3339 Format
+    less_than: string;
+  };
+}
   | {
-      filter_name: "status";
-      filter_value: "active" | "pending";
-    }
+  filter_name: "status";
+  filter_value: "active" | "pending";
+}
   | {
-      filter_name: "oauth_provider";
-      filter_value: string[];
-    }
+  filter_name: "oauth_provider";
+  filter_value: string[];
+}
   | {
-      filter_name: "user_id";
-      filter_value: string[];
-    }
+  filter_name: "user_id";
+  filter_value: string[];
+}
   | {
-      filter_name: "full_name_fuzzy";
-      filter_value: string;
-    }
+  filter_name: "full_name_fuzzy";
+  filter_value: string;
+}
   | {
-      filter_name: "phone_number";
-      filter_value: string[];
-    }
+  filter_name: "phone_number";
+  filter_value: string[];
+}
   | {
-      filter_name: "phone_id";
-      filter_value: string[];
-    }
+  filter_name: "phone_id";
+  filter_value: string[];
+}
   | {
-      filter_name: "phone_verified";
-      filter_value: boolean;
-    }
+  filter_name: "phone_verified";
+  filter_value: boolean;
+}
   | {
-      filter_name: "phone_number_fuzzy";
-      filter_value: string;
-    }
+  filter_name: "phone_number_fuzzy";
+  filter_value: string;
+}
   | {
-      filter_name: "email_address";
-      filter_value: string[];
-    }
+  filter_name: "email_address";
+  filter_value: string[];
+}
   | {
-      filter_name: "email_id";
-      filter_value: string[];
-    }
+  filter_name: "email_id";
+  filter_value: string[];
+}
   | {
-      filter_name: "email_verified";
-      filter_value: boolean;
-    }
+  filter_name: "email_verified";
+  filter_value: boolean;
+}
   | {
-      filter_name: "email_address_fuzzy";
-      filter_value: string;
-    }
+  filter_name: "email_address_fuzzy";
+  filter_value: string;
+}
   | {
-      filter_name: "webauthn_registration_verified";
-      filter_value: boolean;
-    }
+  filter_name: "webauthn_registration_verified";
+  filter_value: boolean;
+}
   | {
-      filter_name: "webauthn_registration_id";
-      filter_value: string[];
-    }
+  filter_name: "webauthn_registration_id";
+  filter_value: string[];
+}
   | {
-      filter_name: "crypto_wallet_id";
-      filter_value: string[];
-    }
+  filter_name: "crypto_wallet_id";
+  filter_value: string[];
+}
   | {
-      filter_name: "crypto_wallet_address";
-      filter_value: string[];
-    }
+  filter_name: "crypto_wallet_address";
+  filter_value: string[];
+}
   | {
-      filter_name: "crypto_wallet_verified";
-      filter_value: boolean;
-    }
+  filter_name: "crypto_wallet_verified";
+  filter_value: boolean;
+}
   | {
-      filter_name: "totp_id";
-      filter_value: string[];
-    }
+  filter_name: "totp_id";
+  filter_value: string[];
+}
   | {
-      filter_name: "totp_verified";
-      filter_value: boolean;
-    };
+  filter_name: "totp_verified";
+  filter_value: boolean;
+};
 
 export interface SearchRequest {
   limit?: number;
@@ -197,6 +182,7 @@ export interface UpdateRequest {
 
 export interface UpdateResponse extends BaseResponse {
   user_id: UserID;
+  user: User,
   emails: Email[];
   phone_numbers: PhoneNumber[];
   crypto_wallets: CryptoWallet[];
@@ -220,22 +206,27 @@ export interface GetPendingResponse extends BaseResponse {
 
 export interface DeleteEmailResponse extends BaseResponse {
   user_id: UserID;
+  user: User;
 }
 
 export interface DeletePhoneNumberResponse extends BaseResponse {
   user_id: UserID;
+  user: User;
 }
 
 export interface DeleteWebAuthnRegistrationResponse extends BaseResponse {
   user_id: UserID;
+  user: User;
 }
 
 export interface DeleteTOTPResponse extends BaseResponse {
   user_id: UserID;
+  user: User;
 }
 
 export interface DeleteCryptoWalletResponse extends BaseResponse {
   user_id: UserID;
+  user: User;
 }
 
 enum mode {
@@ -269,7 +260,7 @@ export class UserSearchIterator {
     return this.mode !== mode.complete;
   }
 
-  async *[Symbol.asyncIterator](): AsyncIterator<User[]> {
+  async* [Symbol.asyncIterator](): AsyncIterator<User[]> {
     while (this.hasNext()) {
       yield this.next();
     }
@@ -289,10 +280,15 @@ export class Users {
   }
 
   create(data: CreateRequest): Promise<CreateResponse> {
-    return request(this.fetchConfig, {
+    return request<WithRawUser<CreateResponse>>(this.fetchConfig, {
       method: "POST",
       url: this.base_path,
       data,
+    }).then((res) => {
+      return {
+        ...res,
+        user: parseUser(res.user),
+      };
     });
   }
 
@@ -324,10 +320,15 @@ export class Users {
   }
 
   update(userID: UserID, data: UpdateRequest): Promise<UpdateResponse> {
-    return request(this.fetchConfig, {
+    return request<WithRawUser<UpdateResponse>>(this.fetchConfig, {
       method: "PUT",
       url: this.endpoint(userID),
       data,
+    }).then((res) => {
+      return {
+        ...res,
+        user: parseUser(res.user),
+      };
     });
   }
 
@@ -347,48 +348,66 @@ export class Users {
   }
 
   deleteEmail(emailID: string): Promise<DeleteEmailResponse> {
-    return request(this.fetchConfig, {
+    return request<WithRawUser<DeleteEmailResponse>>(this.fetchConfig, {
       method: "DELETE",
       url: this.endpoint(`emails/${emailID}`),
+    }).then((res) => {
+      return {
+        ...res,
+        user: parseUser(res.user),
+      };
     });
   }
 
   deletePhoneNumber(phoneID: string): Promise<DeletePhoneNumberResponse> {
-    return request(this.fetchConfig, {
+    return request<WithRawUser<DeletePhoneNumberResponse>>(this.fetchConfig, {
       method: "DELETE",
       url: this.endpoint(`phone_numbers/${phoneID}`),
+    }).then((res) => {
+      return {
+        ...res,
+        user: parseUser(res.user),
+      };
     });
   }
 
   deleteWebAuthnRegistration(
-    webAuthnRegistrationID: string
+    webAuthnRegistrationID: string,
   ): Promise<DeleteWebAuthnRegistrationResponse> {
-    return request(this.fetchConfig, {
+    return request<WithRawUser<DeleteWebAuthnRegistrationResponse>>(this.fetchConfig, {
       method: "DELETE",
       url: this.endpoint(`webauthn_registrations/${webAuthnRegistrationID}`),
+    }).then((res) => {
+      return {
+        ...res,
+        user: parseUser(res.user),
+      };
     });
   }
 
   deleteTOTP(totpID: string): Promise<DeleteTOTPResponse> {
-    return request(this.fetchConfig, {
+    return request<WithRawUser<DeleteTOTPResponse>>(this.fetchConfig, {
       method: "DELETE",
       url: this.endpoint(`totps/${totpID}`),
+    }).then((res) => {
+      return {
+        ...res,
+        user: parseUser(res.user),
+      };
     });
   }
 
   deleteCryptoWallet(
-    cryptoWalletID: string
+    cryptoWalletID: string,
   ): Promise<DeleteCryptoWalletResponse> {
-    return request(this.fetchConfig, {
+    return request<WithRawUser<DeleteCryptoWalletResponse>>(this.fetchConfig, {
       method: "DELETE",
       url: this.endpoint(`crypto_wallets/${cryptoWalletID}`),
+    }).then((res) => {
+      return {
+        ...res,
+        user: parseUser(res.user),
+      };
     });
   }
-}
-
-function parseUser(user: UserRaw): User {
-  return {
-    ...user,
-    created_at: new Date(user.created_at),
-  };
 }

--- a/lib/users.ts
+++ b/lib/users.ts
@@ -49,100 +49,100 @@ export enum UserSearchOperator {
 
 export type UserSearchOperand =
   | {
-  filter_name: "created_at_greater_than";
-  // Timestamp in RFC 3339 Format
-  filter_value: string;
-}
+      filter_name: "created_at_greater_than";
+      // Timestamp in RFC 3339 Format
+      filter_value: string;
+    }
   | {
-  filter_name: "created_at_less_than";
-  // Timestamp in RFC 3339 Format
-  filter_value: string;
-}
+      filter_name: "created_at_less_than";
+      // Timestamp in RFC 3339 Format
+      filter_value: string;
+    }
   | {
-  filter_name: "created_at_between";
-  filter_value: {
-    // Timestamp in RFC 3339 Format
-    greater_than: string;
-    // Timestamp in RFC 3339 Format
-    less_than: string;
-  };
-}
+      filter_name: "created_at_between";
+      filter_value: {
+        // Timestamp in RFC 3339 Format
+        greater_than: string;
+        // Timestamp in RFC 3339 Format
+        less_than: string;
+      };
+    }
   | {
-  filter_name: "status";
-  filter_value: "active" | "pending";
-}
+      filter_name: "status";
+      filter_value: "active" | "pending";
+    }
   | {
-  filter_name: "oauth_provider";
-  filter_value: string[];
-}
+      filter_name: "oauth_provider";
+      filter_value: string[];
+    }
   | {
-  filter_name: "user_id";
-  filter_value: string[];
-}
+      filter_name: "user_id";
+      filter_value: string[];
+    }
   | {
-  filter_name: "full_name_fuzzy";
-  filter_value: string;
-}
+      filter_name: "full_name_fuzzy";
+      filter_value: string;
+    }
   | {
-  filter_name: "phone_number";
-  filter_value: string[];
-}
+      filter_name: "phone_number";
+      filter_value: string[];
+    }
   | {
-  filter_name: "phone_id";
-  filter_value: string[];
-}
+      filter_name: "phone_id";
+      filter_value: string[];
+    }
   | {
-  filter_name: "phone_verified";
-  filter_value: boolean;
-}
+      filter_name: "phone_verified";
+      filter_value: boolean;
+    }
   | {
-  filter_name: "phone_number_fuzzy";
-  filter_value: string;
-}
+      filter_name: "phone_number_fuzzy";
+      filter_value: string;
+    }
   | {
-  filter_name: "email_address";
-  filter_value: string[];
-}
+      filter_name: "email_address";
+      filter_value: string[];
+    }
   | {
-  filter_name: "email_id";
-  filter_value: string[];
-}
+      filter_name: "email_id";
+      filter_value: string[];
+    }
   | {
-  filter_name: "email_verified";
-  filter_value: boolean;
-}
+      filter_name: "email_verified";
+      filter_value: boolean;
+    }
   | {
-  filter_name: "email_address_fuzzy";
-  filter_value: string;
-}
+      filter_name: "email_address_fuzzy";
+      filter_value: string;
+    }
   | {
-  filter_name: "webauthn_registration_verified";
-  filter_value: boolean;
-}
+      filter_name: "webauthn_registration_verified";
+      filter_value: boolean;
+    }
   | {
-  filter_name: "webauthn_registration_id";
-  filter_value: string[];
-}
+      filter_name: "webauthn_registration_id";
+      filter_value: string[];
+    }
   | {
-  filter_name: "crypto_wallet_id";
-  filter_value: string[];
-}
+      filter_name: "crypto_wallet_id";
+      filter_value: string[];
+    }
   | {
-  filter_name: "crypto_wallet_address";
-  filter_value: string[];
-}
+      filter_name: "crypto_wallet_address";
+      filter_value: string[];
+    }
   | {
-  filter_name: "crypto_wallet_verified";
-  filter_value: boolean;
-}
+      filter_name: "crypto_wallet_verified";
+      filter_value: boolean;
+    }
   | {
-  filter_name: "totp_id";
-  filter_value: string[];
-}
+      filter_name: "totp_id";
+      filter_value: string[];
+    }
   | {
-  filter_name: "totp_verified";
-  filter_value: boolean;
-};
+      filter_name: "totp_verified";
+      filter_value: boolean;
+    };
 
 export interface SearchRequest {
   limit?: number;
@@ -182,7 +182,7 @@ export interface UpdateRequest {
 
 export interface UpdateResponse extends BaseResponse {
   user_id: UserID;
-  user: User,
+  user: User;
   emails: Email[];
   phone_numbers: PhoneNumber[];
   crypto_wallets: CryptoWallet[];
@@ -260,7 +260,7 @@ export class UserSearchIterator {
     return this.mode !== mode.complete;
   }
 
-  async* [Symbol.asyncIterator](): AsyncIterator<User[]> {
+  async *[Symbol.asyncIterator](): AsyncIterator<User[]> {
     while (this.hasNext()) {
       yield this.next();
     }
@@ -372,12 +372,15 @@ export class Users {
   }
 
   deleteWebAuthnRegistration(
-    webAuthnRegistrationID: string,
+    webAuthnRegistrationID: string
   ): Promise<DeleteWebAuthnRegistrationResponse> {
-    return request<WithRawUser<DeleteWebAuthnRegistrationResponse>>(this.fetchConfig, {
-      method: "DELETE",
-      url: this.endpoint(`webauthn_registrations/${webAuthnRegistrationID}`),
-    }).then((res) => {
+    return request<WithRawUser<DeleteWebAuthnRegistrationResponse>>(
+      this.fetchConfig,
+      {
+        method: "DELETE",
+        url: this.endpoint(`webauthn_registrations/${webAuthnRegistrationID}`),
+      }
+    ).then((res) => {
       return {
         ...res,
         user: parseUser(res.user),
@@ -398,7 +401,7 @@ export class Users {
   }
 
   deleteCryptoWallet(
-    cryptoWalletID: string,
+    cryptoWalletID: string
   ): Promise<DeleteCryptoWalletResponse> {
     return request<WithRawUser<DeleteCryptoWalletResponse>>(this.fetchConfig, {
       method: "DELETE",

--- a/lib/webauthn.ts
+++ b/lib/webauthn.ts
@@ -1,4 +1,4 @@
-import { request, Session } from "./shared";
+import { parseUser, request, Session, User, WithRawUser } from "./shared";
 
 import type { BaseResponse, fetchConfig } from "./shared";
 import { UserID } from "./users";
@@ -44,6 +44,7 @@ export interface AuthenticateRequest {
 
 export interface AuthenticateResponse extends BaseResponse {
   user_id: UserID;
+  user: User;
   webauthn_registration_id: string;
   session_token?: string;
   session_jwt?: string;
@@ -89,10 +90,15 @@ export class WebAuthn {
   }
 
   authenticate(data: AuthenticateRequest): Promise<AuthenticateResponse> {
-    return request(this.fetchConfig, {
+    return request<WithRawUser<AuthenticateResponse>>(this.fetchConfig, {
       method: "POST",
       url: this.endpoint("authenticate"),
       data,
+    }).then((res) => {
+      return {
+        ...res,
+        user: parseUser(res.user),
+      };
     });
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "stytch",
-  "version": "5.1.5",
+  "version": "5.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stytch",
-  "version": "5.1.5",
+  "version": "5.2.0",
   "description": "A wrapper for the Stytch API",
   "types": "./types/lib/index.d.ts",
   "main": "./dist/index.js",

--- a/types/lib/crypto_wallets.d.ts
+++ b/types/lib/crypto_wallets.d.ts
@@ -1,4 +1,4 @@
-import { Session, fetchConfig } from "./shared";
+import { Session, fetchConfig, User } from "./shared";
 import type { BaseResponse } from "./shared";
 import { UserID } from "./users";
 export interface AuthenticateStartRequest {
@@ -21,6 +21,7 @@ export interface AuthenticateRequest {
 }
 export interface AuthenticateResponse extends BaseResponse {
     user_id: UserID;
+    user: User;
     session_token?: string;
     session_jwt?: string;
     session?: Session;

--- a/types/lib/magic_links.d.ts
+++ b/types/lib/magic_links.d.ts
@@ -1,4 +1,4 @@
-import { Session } from "./shared";
+import { Session, User } from "./shared";
 import type { Attributes, BaseResponse, Name, fetchConfig } from "./shared";
 export interface SendByEmailRequest {
     email: string;
@@ -58,6 +58,7 @@ export interface AuthenticateRequest {
 }
 export interface AuthenticateResponse extends BaseResponse {
     user_id: string;
+    user: User;
     method_id: string;
     session_token?: string;
     session_jwt?: string;

--- a/types/lib/oauth.d.ts
+++ b/types/lib/oauth.d.ts
@@ -1,4 +1,4 @@
-import type { BaseResponse, Session, fetchConfig } from "./shared";
+import type { BaseResponse, Session, fetchConfig, User } from "./shared";
 export interface AuthenticateRequest {
     session_token?: string;
     session_jwt?: string;
@@ -6,6 +6,7 @@ export interface AuthenticateRequest {
 }
 export interface AuthenticateResponse extends BaseResponse {
     user_id: string;
+    user: User;
     provider_subject: string;
     provider_type: string;
     session_token?: string;

--- a/types/lib/otps.d.ts
+++ b/types/lib/otps.d.ts
@@ -1,4 +1,4 @@
-import { fetchConfig } from "./shared";
+import { fetchConfig, User } from "./shared";
 import type { Attributes, BaseResponse, Session } from "./shared";
 export interface OTPEmailSendRequest {
     email: string;
@@ -74,6 +74,7 @@ export interface AuthenticateRequest {
 }
 export interface AuthenticateResponse extends BaseResponse {
     user_id: string;
+    user: User;
     method_id: string;
     session_token?: string;
     session_jwt?: string;

--- a/types/lib/sessions.d.ts
+++ b/types/lib/sessions.d.ts
@@ -1,5 +1,5 @@
 import * as jose from "jose";
-import { Session, fetchConfig } from "./shared";
+import { Session, fetchConfig, User } from "./shared";
 import type { BaseResponse } from "./shared";
 export interface GetRequest {
     user_id: string;
@@ -28,6 +28,7 @@ export interface AuthenticateRequest {
 }
 export interface AuthenticateResponse extends BaseResponse {
     session: Session;
+    user: User;
     session_token: string;
     session_jwt: string;
 }

--- a/types/lib/shared.d.ts
+++ b/types/lib/shared.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="node" />
 import * as http from "http";
+import { UserID } from "./users";
 export interface Attributes {
     ip_address?: string;
     user_agent?: string;
@@ -29,6 +30,18 @@ export interface WebAuthnRegistration {
 export interface TOTP {
     totp_id: string;
     verified: boolean;
+}
+export interface User {
+    user_id: UserID;
+    created_at: Date;
+    status: string;
+    name: Name;
+    emails: Email[];
+    phone_numbers: PhoneNumber[];
+    providers: OAuthProvider[];
+    webauthn_registrations: WebAuthnRegistration[];
+    totps: TOTP[];
+    crypto_wallets: CryptoWallet[];
 }
 export interface CryptoWallet {
     crypto_wallet_id: string;
@@ -183,3 +196,12 @@ export declare type requestConfig = {
     data?: unknown;
 };
 export declare function request<T>(fetchConfig: fetchConfig, requestConfig: requestConfig): Promise<T>;
+export declare type UserRaw = Omit<User, "created_at"> & {
+    created_at: string;
+};
+export declare type WithRawUser<T extends {
+    "user": User;
+}> = Omit<T, "user"> & {
+    user: UserRaw;
+};
+export declare function parseUser(user: UserRaw): User;

--- a/types/lib/shared.d.ts
+++ b/types/lib/shared.d.ts
@@ -200,7 +200,7 @@ export declare type UserRaw = Omit<User, "created_at"> & {
     created_at: string;
 };
 export declare type WithRawUser<T extends {
-    "user": User;
+    user: User;
 }> = Omit<T, "user"> & {
     user: UserRaw;
 };

--- a/types/lib/totps.d.ts
+++ b/types/lib/totps.d.ts
@@ -1,3 +1,4 @@
+import { User } from "./shared";
 import type { BaseResponse, Session, fetchConfig } from "./shared";
 export interface TOTP {
     totp_id: string;
@@ -23,6 +24,7 @@ export interface AuthenticateRequest {
 }
 export interface AuthenticateResponse extends BaseResponse {
     user_id: string;
+    user: User;
     totp_id: string;
     session_token?: string;
     session_jwt?: string;
@@ -44,6 +46,7 @@ export interface RecoverRequest {
 }
 export interface RecoverResponse extends BaseResponse {
     user_id: string;
+    user: User;
     totp_id: string;
     session_token?: string;
     session_jwt?: string;

--- a/types/lib/users.d.ts
+++ b/types/lib/users.d.ts
@@ -1,5 +1,5 @@
-import { OAuthProvider } from "./shared";
-import type { Attributes, BaseResponse, Email, Name, PhoneNumber, WebAuthnRegistration, TOTP, CryptoWallet, fetchConfig } from "./shared";
+import { User } from "./shared";
+import type { Attributes, BaseResponse, Email, Name, PhoneNumber, TOTP, CryptoWallet, fetchConfig } from "./shared";
 export declare type UserID = string;
 export interface PendingUser {
     user_id: UserID;
@@ -20,21 +20,10 @@ export interface CreateRequest {
 }
 export interface CreateResponse extends BaseResponse {
     user_id: UserID;
+    user: User;
     email_id: string;
     phone_id: string;
     status: string;
-}
-interface User {
-    user_id: UserID;
-    created_at: Date;
-    status: string;
-    name: Name;
-    emails: Email[];
-    phone_numbers: PhoneNumber[];
-    providers: OAuthProvider[];
-    webauthn_registrations: WebAuthnRegistration[];
-    totps: TOTP[];
-    crypto_wallets: CryptoWallet[];
 }
 export declare type GetResponse = BaseResponse & User;
 export declare enum UserSearchOperator {
@@ -142,6 +131,7 @@ export interface UpdateRequest {
 }
 export interface UpdateResponse extends BaseResponse {
     user_id: UserID;
+    user: User;
     emails: Email[];
     phone_numbers: PhoneNumber[];
     crypto_wallets: CryptoWallet[];
@@ -161,18 +151,23 @@ export interface GetPendingResponse extends BaseResponse {
 }
 export interface DeleteEmailResponse extends BaseResponse {
     user_id: UserID;
+    user: User;
 }
 export interface DeletePhoneNumberResponse extends BaseResponse {
     user_id: UserID;
+    user: User;
 }
 export interface DeleteWebAuthnRegistrationResponse extends BaseResponse {
     user_id: UserID;
+    user: User;
 }
 export interface DeleteTOTPResponse extends BaseResponse {
     user_id: UserID;
+    user: User;
 }
 export interface DeleteCryptoWalletResponse extends BaseResponse {
     user_id: UserID;
+    user: User;
 }
 export declare class UserSearchIterator {
     private client;
@@ -201,4 +196,3 @@ export declare class Users {
     deleteTOTP(totpID: string): Promise<DeleteTOTPResponse>;
     deleteCryptoWallet(cryptoWalletID: string): Promise<DeleteCryptoWalletResponse>;
 }
-export {};

--- a/types/lib/webauthn.d.ts
+++ b/types/lib/webauthn.d.ts
@@ -1,4 +1,4 @@
-import { Session } from "./shared";
+import { Session, User } from "./shared";
 import type { BaseResponse, fetchConfig } from "./shared";
 import { UserID } from "./users";
 export interface RegisterStartRequest {
@@ -35,6 +35,7 @@ export interface AuthenticateRequest {
 }
 export interface AuthenticateResponse extends BaseResponse {
     user_id: UserID;
+    user: User;
     webauthn_registration_id: string;
     session_token?: string;
     session_jwt?: string;


### PR DESCRIPTION
We now return a user object from the following calls:
- Create User
- Update User
- Authenticate Magic Link
- Authenticate OTP
- Authenticate OAuth
- Authenticate TOTP
- Authenticate WebAuthn
- Authenticate Crypto Wallet
- Delete Email / Phone # / TOTP / WebAuth / Crypto Wallet