### PR TITLE
feat: Add types for PKCE in OAuth and EML flows

### DIFF
--- a/lib/magic_links.ts
+++ b/lib/magic_links.ts
@@ -9,6 +9,7 @@ export interface SendByEmailRequest {
   login_expiration_minutes?: number;
   signup_expiration_minutes?: number;
   attributes?: Attributes;
+  code_challenge?: string;
 }
 
 export interface SendByEmailResponse extends BaseResponse {
@@ -24,6 +25,7 @@ export interface LoginOrCreateByEmailRequest {
   signup_expiration_minutes?: number;
   create_user_as_pending?: boolean;
   attributes?: Attributes;
+  code_challenge?: string;
 }
 
 export interface LoginOrCreateByEmailResponse extends BaseResponse {
@@ -65,6 +67,7 @@ export interface AuthenticateRequest {
   session_token?: string;
   session_jwt?: string;
   session_duration_minutes?: number;
+  code_verifier?: string;
 }
 
 export interface AuthenticateResponse extends BaseResponse {

--- a/lib/oauth.ts
+++ b/lib/oauth.ts
@@ -11,6 +11,7 @@ export interface AuthenticateRequest {
   session_token?: string;
   session_jwt?: string;
   session_duration_minutes?: number;
+  code_verifier?: string;
 }
 
 export interface AuthenticateResponse extends BaseResponse {

--- a/types/lib/magic_links.d.ts
+++ b/types/lib/magic_links.d.ts
@@ -7,6 +7,7 @@ export interface SendByEmailRequest {
     login_expiration_minutes?: number;
     signup_expiration_minutes?: number;
     attributes?: Attributes;
+    code_challenge?: string;
 }
 export interface SendByEmailResponse extends BaseResponse {
     user_id: string;
@@ -20,6 +21,7 @@ export interface LoginOrCreateByEmailRequest {
     signup_expiration_minutes?: number;
     create_user_as_pending?: boolean;
     attributes?: Attributes;
+    code_challenge?: string;
 }
 export interface LoginOrCreateByEmailResponse extends BaseResponse {
     user_id: string;
@@ -55,6 +57,7 @@ export interface AuthenticateRequest {
     session_token?: string;
     session_jwt?: string;
     session_duration_minutes?: number;
+    code_verifier?: string;
 }
 export interface AuthenticateResponse extends BaseResponse {
     user_id: string;

--- a/types/lib/oauth.d.ts
+++ b/types/lib/oauth.d.ts
@@ -3,6 +3,7 @@ export interface AuthenticateRequest {
     session_token?: string;
     session_jwt?: string;
     session_duration_minutes?: number;
+    code_verifier?: string;
 }
 export interface AuthenticateResponse extends BaseResponse {
     user_id: string;


### PR DESCRIPTION
Adds `code_challenge` to magic link start methods, and `code_verifier` to magic link and OAuth authenticate methods.

@stytchauth/client-libraries - any suggestion as to whether this should be a patch or a minor?