### PR TITLE
fix: Bump node-fetch dep to pick up security release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10171,7 +10171,7 @@
       "resolved": "https://registry.npmjs.org/isomorphic-unfetch/-/isomorphic-unfetch-3.1.0.tgz",
       "integrity": "sha512-geDJjpoZ8N0kWexiwkX8F9NkTsXhetLPVbZFQ+JTW239QNOwvB0gniuR1Wc6f0AMTn7/mFGyXvHTifrCp/GH8Q==",
       "requires": {
-        "node-fetch": "^2.6.1",
+        "node-fetch": "2.6.7",
         "unfetch": "^4.2.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -54,6 +54,11 @@
     "isomorphic-unfetch": "^3.1.0",
     "jose": "^4.6.0"
   },
+  "overrides": {
+    "isomorphic-unfetch": {
+      "node-fetch": "2.6.7"
+    }
+  },
   "eslintConfig": {
     "extends": "airbnb",
     "env": {


### PR DESCRIPTION
Force bumps `node-fetch` to 2.6.7 to resolve https://nvd.nist.gov/vuln/detail/CVE-2022-0235
```
stytch@5.4.0 /Users/maxwellgerber/work/client-libs/stytch-node
└─┬ isomorphic-unfetch@3.1.0
  └── node-fetch@2.6.7
```