### PR TITLE
fix: Extract custom claims from JWTs

### DIFF
--- a/dist/sessions.js
+++ b/dist/sessions.js
@@ -142,8 +142,6 @@ class Sessions {
 
 
     const {
-      // These
-
       /* eslint-disable @typescript-eslint/no-unused-vars */
       aud: _aud,
       exp: _exp,

--- a/lib/sessions.ts
+++ b/lib/sessions.ts
@@ -95,6 +95,11 @@ type SessionClaim = {
   expires_at: string;
   attributes: Attributes;
   authentication_factors: AuthenticationFactor[];
+  // Since custom claims are free-from JSON, the best we can say is that we collect them into an
+  // object with string keys.
+  //
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  custom_claims: Record<string, any>;
 };
 
 export class Sessions {
@@ -232,7 +237,27 @@ export class Sessions {
       }
     }
 
-    const claim = payload[sessionClaim] as SessionClaim;
+    // The custom claim set is all the claims in the payload except for the standard claims and
+    // the Stytch session claim. The cleanest way to collect those seems to be naming what we want
+    // to omit and using ...rest for to collect the custom claims.
+    const {
+      // These
+      /* eslint-disable @typescript-eslint/no-unused-vars */
+      aud: _aud,
+      exp: _exp,
+      iat: _iat,
+      iss: _iss,
+      jti: _jti,
+      nbf: _nbf,
+      sub: _sub,
+      /* eslint-enable @typescript-eslint/no-unused-vars */
+
+      [sessionClaim]: stytchClaim,
+      ...customClaims
+    } = payload;
+
+    const claim = stytchClaim as SessionClaim;
+
     return {
       session_id: claim.id,
       attributes: claim.attributes,
@@ -247,6 +272,8 @@ export class Sessions {
       last_accessed_at: new Date(claim.last_accessed_at),
       // For JWTs that include it, prefer the inner expires_at claim.
       expires_at: new Date(claim.expires_at || (payload.exp || 0) * 1000),
+
+      custom_claims: customClaims,
     };
   }
 

--- a/lib/sessions.ts
+++ b/lib/sessions.ts
@@ -241,7 +241,6 @@ export class Sessions {
     // the Stytch session claim. The cleanest way to collect those seems to be naming what we want
     // to omit and using ...rest for to collect the custom claims.
     const {
-      // These
       /* eslint-disable @typescript-eslint/no-unused-vars */
       aud: _aud,
       exp: _exp,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stytch",
-  "version": "5.11.0",
+  "version": "5.11.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "stytch",
-      "version": "5.11.0",
+      "version": "5.11.1",
       "license": "MIT",
       "dependencies": {
         "isomorphic-base64": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stytch",
-  "version": "5.11.0",
+  "version": "5.11.1",
   "description": "A wrapper for the Stytch API",
   "types": "./types/lib/index.d.ts",
   "main": "./dist/index.js",

--- a/test/sandbox.test.ts
+++ b/test/sandbox.test.ts
@@ -51,7 +51,7 @@ describeIf(
             expect(err.status_code).toEqual(401);
             expect(err.error_type).toEqual("unable_to_auth_magic_link");
             expect(err.error_message).toEqual(
-              "Magic link could not be authenticated.",
+              "The magic link could not be authenticated because it was either already used or expired. Send another magic link to this user."
             );
             expect(err.error_url).toEqual(
               "https://stytch.com/docs/api/errors/401"
@@ -65,7 +65,9 @@ describeIf(
           .catch((err) => {
             expect(err.status_code).toEqual(404);
             expect(err.error_type).toEqual("magic_link_not_found");
-            expect(err.error_message).toEqual("Magic Link could not be found.");
+            expect(err.error_message).toEqual(
+              "The magic link could not be authenticated, try sending another magic link to the user."
+            );
             expect(err.error_url).toEqual(
               "https://stytch.com/docs/api/errors/404"
             );

--- a/test/sandbox.test.ts
+++ b/test/sandbox.test.ts
@@ -39,7 +39,7 @@ describeIf(
           .then((res) => {
             expect(res.status_code).toEqual(200);
             expect(res.user_id).toEqual(
-              "user-test-e3795c81-f849-4167-bfda-e4a6e9c280fd",
+              "user-test-e3795c81-f849-4167-bfda-e4a6e9c280fd"
             );
           });
       });
@@ -54,7 +54,7 @@ describeIf(
               "Magic link could not be authenticated.",
             );
             expect(err.error_url).toEqual(
-              "https://stytch.com/docs/api/errors/401",
+              "https://stytch.com/docs/api/errors/401"
             );
           });
       });
@@ -67,7 +67,7 @@ describeIf(
             expect(err.error_type).toEqual("magic_link_not_found");
             expect(err.error_message).toEqual("Magic Link could not be found.");
             expect(err.error_url).toEqual(
-              "https://stytch.com/docs/api/errors/404",
+              "https://stytch.com/docs/api/errors/404"
             );
           });
       });
@@ -84,7 +84,7 @@ describeIf(
           .then((res) => {
             expect(res.status_code).toEqual(200);
             expect(res.user_id).toEqual(
-              "user-test-e3795c81-f849-4167-bfda-e4a6e9c280fd",
+              "user-test-e3795c81-f849-4167-bfda-e4a6e9c280fd"
             );
           });
       });
@@ -101,7 +101,7 @@ describeIf(
           .then((res) => {
             expect(res.status_code).toEqual(200);
             expect(res.user_id).toEqual(
-              "user-test-e3795c81-f849-4167-bfda-e4a6e9c280fd",
+              "user-test-e3795c81-f849-4167-bfda-e4a6e9c280fd"
             );
           });
       });
@@ -117,7 +117,7 @@ describeIf(
           .then((res) => {
             expect(res.status_code).toEqual(200);
             expect(res.user_id).toEqual(
-              "user-test-e3795c81-f849-4167-bfda-e4a6e9c280fd",
+              "user-test-e3795c81-f849-4167-bfda-e4a6e9c280fd"
             );
           });
       });
@@ -140,7 +140,7 @@ describeIf(
         return expect(
           client.sessions.authenticate({
             session_token: "WJtR5BCy38Szd5AfoDpf0iqFKEt4EE5JhjlWUY7l3FtY",
-          }),
+          })
         ).resolves.toMatchObject({
           status_code: 200,
           session_token: "WJtR5BCy38Szd5AfoDpf0iqFKEt4EE5JhjlWUY7l3FtY",
@@ -155,7 +155,7 @@ describeIf(
         return expect(
           client.sessions.authenticate({
             session_token: "59cnLELtq5cFVS6uYK9f-pAWzBkhqZl8AvLhbhOvKNWw",
-          }),
+          })
         ).rejects.toMatchObject({
           status_code: 404,
           error_type: "session_not_found",
@@ -163,7 +163,10 @@ describeIf(
       });
 
       test("Using a custom agent", async () => {
-        const lookupSpy = jest.spyOn(dns, 'lookup') as unknown as typeof dns.lookup;
+        const lookupSpy = jest.spyOn(
+          dns,
+          "lookup"
+        ) as unknown as typeof dns.lookup;
         const agent = new https.Agent({
           lookup: lookupSpy,
         });
@@ -174,12 +177,16 @@ describeIf(
           agent,
         });
 
-        await client.magicLinks
-          .authenticate("DOYoip3rvIMMW5lgItikFK-Ak1CfMsgjuiCyI7uuU94=");
+        await client.magicLinks.authenticate(
+          "DOYoip3rvIMMW5lgItikFK-Ak1CfMsgjuiCyI7uuU94="
+        );
 
         expect(lookupSpy).toHaveBeenCalledWith(
-          'test.stytch.com', expect.anything(), expect.anything());
+          "test.stytch.com",
+          expect.anything(),
+          expect.anything()
+        );
       });
     });
-  },
+  }
 );

--- a/test/sessions.test.ts
+++ b/test/sessions.test.ts
@@ -3,7 +3,6 @@ import { Sessions } from "../lib/sessions";
 import { ClientError } from "../lib/errors";
 import { MOCK_FETCH_CONFIG, mockRequest } from "./helpers";
 
-
 function jwtConfig(projectID: string) {
   return {
     projectID,
@@ -42,13 +41,13 @@ describe("sessions.get", () => {
     });
     const sessions = new Sessions(
       MOCK_FETCH_CONFIG,
-      jwtConfig("project-test-00000000-0000-4000-8000-000000000000"),
+      jwtConfig("project-test-00000000-0000-4000-8000-000000000000")
     );
 
     return expect(
       sessions.get({
         user_id: "user-test-22222222-2222-4222-8222-222222222222",
-      }),
+      })
     ).resolves.toMatchObject({
       status_code: 200,
       sessions: [
@@ -90,14 +89,14 @@ describe("sessions.authenticate", () => {
     });
     const sessions = new Sessions(
       MOCK_FETCH_CONFIG,
-      jwtConfig("project-test-00000000-0000-4000-8000-000000000000"),
+      jwtConfig("project-test-00000000-0000-4000-8000-000000000000")
     );
 
     return expect(
       sessions.authenticate({
         session_token: "mZAYn5aLEqKUlZ_Ad9U_fWr38GaAQ1oFAhT8ds245v7Q",
         session_duration_minutes: 60,
-      }),
+      })
     ).resolves.toMatchObject({
       session_token: "mZAYn5aLEqKUlZ_Ad9U_fWr38GaAQ1oFAhT8ds245v7Q",
       session: {
@@ -123,13 +122,13 @@ describe("sessions.revoke", () => {
     });
     const sessions = new Sessions(
       MOCK_FETCH_CONFIG,
-      jwtConfig("project-test-00000000-0000-4000-8000-000000000000"),
+      jwtConfig("project-test-00000000-0000-4000-8000-000000000000")
     );
 
     return expect(
       sessions.revoke({
         session_token: "mZAYn5aLEqKUlZ_Ad9U_fWr38GaAQ1oFAhT8ds245v7Q",
-      }),
+      })
     ).resolves.toEqual({
       status: 200,
     });
@@ -148,11 +147,11 @@ describe("sessions.jwks", () => {
     });
     const sessions = new Sessions(
       MOCK_FETCH_CONFIG,
-      jwtConfig("project-test-00000000-0000-4000-8000-000000000000"),
+      jwtConfig("project-test-00000000-0000-4000-8000-000000000000")
     );
 
     return expect(
-      sessions.jwks("project-test-11111111-1111-4111-8111-111111111111"),
+      sessions.jwks("project-test-11111111-1111-4111-8111-111111111111")
     ).resolves.toEqual({ status: 200 });
   });
 });
@@ -358,17 +357,17 @@ describe("sessions.authenticateJwtLocal", () => {
       sessions.authenticateJwtLocal(jwtWithExpiresAt, {
         current_date: appNow,
         clock_tolerance_seconds: 9,
-      }),
+      })
     ).rejects.toHaveProperty("code", "jwt_invalid");
 
     await expect(
       sessions.authenticateJwtLocal(jwtWithExpiresAt, {
         current_date: appNow,
         clock_tolerance_seconds: 10,
-      }),
+      })
     ).resolves.toHaveProperty(
       "user_id",
-      "user-live-fde03dd1-fff7-4b3c-9b31-ead3fbc224de",
+      "user-live-fde03dd1-fff7-4b3c-9b31-ead3fbc224de"
     );
   });
 
@@ -394,10 +393,10 @@ describe("sessions.authenticateJwtLocal", () => {
       sessions.authenticateJwtLocal(jwtWithExpiresAt, {
         current_date: dateAdd(startedAt, +3),
         max_token_age_seconds: 5,
-      }),
+      })
     ).resolves.toHaveProperty(
       "user_id",
-      "user-live-fde03dd1-fff7-4b3c-9b31-ead3fbc224de",
+      "user-live-fde03dd1-fff7-4b3c-9b31-ead3fbc224de"
     );
 
     const promise = sessions.authenticateJwtLocal(jwtWithExpiresAt, {


### PR DESCRIPTION
The return value of `authenticateJwtLocal` was missing the `custom_claims` object that `authenticate` populates. Because `authenticateJwt` prefers local validation over sending an API request, it would only include the custom claims when it had to fall back to the API request.

This change adds custom claim extraction to `authenticateJwtLocal` so all three methods agree again.
