### PR TITLE
fix: Remove incorrect type change to SessionClaim

### DIFF
--- a/lib/sessions.ts
+++ b/lib/sessions.ts
@@ -95,11 +95,6 @@ type SessionClaim = {
   expires_at: string;
   attributes: Attributes;
   authentication_factors: AuthenticationFactor[];
-  // Since custom claims are free-from JSON, the best we can say is that we collect them into an
-  // object with string keys.
-  //
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  custom_claims: Record<string, any>;
 };
 
 export class Sessions {


### PR DESCRIPTION
This was an error in #157. When I was developing the test for it, I had put the claims in the wrong place, so I needed this type definition to match.

But the session claim is a _sibling_ of the custom claims, not the parent, so this is incorrect.

# Reviewer Notes

No version update in this one because I caught this before completing the release. This will go out in v5.11.1 along with #157.
