### PR TITLE
Add user fields to TOTP create response

### DIFF
--- a/lib/totps.ts
+++ b/lib/totps.ts
@@ -18,6 +18,8 @@ export interface CreateResponse extends BaseResponse {
   secret: string;
   qr_code: string;
   recovery_codes: string[];
+  user: User;
+  user_id: string;
 }
 
 export interface AuthenticateRequest {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stytch",
-  "version": "5.11.1",
+  "version": "5.12.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "stytch",
-      "version": "5.11.1",
+      "version": "5.12.0",
       "license": "MIT",
       "dependencies": {
         "isomorphic-base64": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stytch",
-  "version": "5.11.1",
+  "version": "5.12.0",
   "description": "A wrapper for the Stytch API",
   "types": "./types/lib/index.d.ts",
   "main": "./dist/index.js",

--- a/types/lib/totps.d.ts
+++ b/types/lib/totps.d.ts
@@ -14,6 +14,8 @@ export interface CreateResponse extends BaseResponse {
     secret: string;
     qr_code: string;
     recovery_codes: string[];
+    user: User;
+    user_id: string;
 }
 export interface AuthenticateRequest {
     user_id: string;


### PR DESCRIPTION
The TOTP create endpoint now returns a user ID and user field. This PR adds these fields to the TOTP CreateResponse in the node client library.