### PR TITLE
ci: Ensure the CI project always has a JWT signing key

### DIFF
--- a/test/sandbox.test.ts
+++ b/test/sandbox.test.ts
@@ -138,7 +138,7 @@ describeIf(
     });
 
     describe("sessions.authenticate", () => {
-      test("success", () => {
+      test("success", async () => {
         // Make sure there's a key that can be used to sign the sandbox JWT.
         //
         // You should never need to trigger this for a real project in either environment (Test or
@@ -153,7 +153,7 @@ describeIf(
         // 2. Sandbox requests still sign the JWTs so you can test your validation code for the
         //    (nonexistent) session, but they aren't allowed to persist anything.
         //
-        client.sessions.jwks(env("PROJECT_ID"));
+        await client.sessions.jwks(env("PROJECT_ID"));
 
         return expect(
           client.sessions.authenticate({

--- a/test/sandbox.test.ts
+++ b/test/sandbox.test.ts
@@ -139,6 +139,22 @@ describeIf(
 
     describe("sessions.authenticate", () => {
       test("success", () => {
+        // Make sure there's a key that can be used to sign the sandbox JWT.
+        //
+        // You should never need to trigger this for a real project in either environment (Test or
+        // Live). Signing keys will be automatically generated for your project the first time the
+        // API needs one to sign a JWT. Those keys will be automatically rotated as you continue
+        // to use sessions.
+        //
+        // We only need this in this test suite because it's a very narrow edge case:
+        //
+        // 1. The credentials we use for CI are for a project that never creates real sessions
+        //    (and therefore doesn't naturally get a signing key).
+        // 2. Sandbox requests still sign the JWTs so you can test your validation code for the
+        //    (nonexistent) session, but they aren't allowed to persist anything.
+        //
+        client.sessions.jwks(env("PROJECT_ID"));
+
         return expect(
           client.sessions.authenticate({
             session_token: "WJtR5BCy38Szd5AfoDpf0iqFKEt4EE5JhjlWUY7l3FtY",

--- a/test/sandbox.test.ts
+++ b/test/sandbox.test.ts
@@ -140,22 +140,10 @@ describeIf(
     describe("sessions.authenticate", () => {
       test("success", async () => {
         // Make sure there's a key that can be used to sign the sandbox JWT.
-        //
-        // You should never need to trigger this for a real project in either environment (Test or
-        // Live). Signing keys will be automatically generated for your project the first time the
-        // API needs one to sign a JWT. Those keys will be automatically rotated as you continue
-        // to use sessions.
-        //
-        // We only need this in this test suite because it's a very narrow edge case:
-        //
-        // 1. The credentials we use for CI are for a project that never creates real sessions
-        //    (and therefore doesn't naturally get a signing key).
-        // 2. Sandbox requests still sign the JWTs so you can test your validation code for the
-        //    (nonexistent) session, but they aren't allowed to persist anything.
-        //
-        await client.sessions.jwks(env("PROJECT_ID"));
+        const jwks = await client.sessions.jwks(env("PROJECT_ID"));
+        expect(jwks.keys.length).toBeGreaterThan(0);
 
-        return expect(
+        await expect(
           client.sessions.authenticate({
             session_token: "WJtR5BCy38Szd5AfoDpf0iqFKEt4EE5JhjlWUY7l3FtY",
           })


### PR DESCRIPTION
The sandbox tests started failing in CI recently. The API was unable to sign the sandbox-session JWT for the CI project because the original signing key expired.

Normally, the key would automatically be rotated when it was necessary to sign the JWT for a real session. However, the CI project only ever issues sandbox requests and never starts a real session. So this uses the workaround of fetching the JWKS to trigger signing key generation outside the sandbox.

This is a _very_ specific edge case that would only be encountered by a very new or very old Stytch project whose first interaction with sessions is to try and validate the sandbox token. You should never have to use this anywhere in your real projects, Test or Live.
