### PR TITLE
BACK-1935 OTP/magic link send attach method updates

### DIFF
--- a/lib/magic_links.ts
+++ b/lib/magic_links.ts
@@ -10,6 +10,9 @@ export interface SendByEmailRequest {
   signup_expiration_minutes?: number;
   attributes?: Attributes;
   code_challenge?: string;
+  user_id?: string;
+  session_token?: string;
+  session_jwt?: string;
 }
 
 export interface SendByEmailResponse extends BaseResponse {

--- a/lib/otps.ts
+++ b/lib/otps.ts
@@ -6,6 +6,9 @@ export interface OTPEmailSendRequest {
   email: string;
   expiration_minutes?: number;
   attributes?: Attributes;
+  user_id?: string;
+  session_token?: string;
+  session_jwt?: string;
 }
 
 export interface OTPEmailSendResponse extends BaseResponse {
@@ -30,6 +33,9 @@ export interface SendOTPBySMSRequest {
   phone_number: string;
   expiration_minutes?: number;
   attributes?: Attributes;
+  user_id?: string;
+  session_token?: string;
+  session_jwt?: string;
 }
 
 export interface SendOTPBySMSResponse extends BaseResponse {
@@ -54,6 +60,9 @@ export interface OTPWhatsAppSendRequest {
   phone_number: string;
   expiration_minutes?: number;
   attributes?: Attributes;
+  user_id?: string;
+  session_token?: string;
+  session_jwt?: string;
 }
 
 export interface OTPWhatsAppSendResponse extends BaseResponse {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stytch",
-  "version": "5.12.1",
+  "version": "5.12.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "stytch",
-      "version": "5.12.1",
+      "version": "5.12.2",
       "license": "MIT",
       "dependencies": {
         "isomorphic-base64": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stytch",
-  "version": "5.12.1",
+  "version": "5.12.2",
   "description": "A wrapper for the Stytch API",
   "types": "./types/lib/index.d.ts",
   "main": "./dist/index.js",

--- a/types/lib/magic_links.d.ts
+++ b/types/lib/magic_links.d.ts
@@ -8,6 +8,9 @@ export interface SendByEmailRequest {
     signup_expiration_minutes?: number;
     attributes?: Attributes;
     code_challenge?: string;
+    user_id?: string;
+    session_token?: string;
+    session_jwt?: string;
 }
 export interface SendByEmailResponse extends BaseResponse {
     user_id: string;

--- a/types/lib/otps.d.ts
+++ b/types/lib/otps.d.ts
@@ -4,6 +4,9 @@ export interface OTPEmailSendRequest {
     email: string;
     expiration_minutes?: number;
     attributes?: Attributes;
+    user_id?: string;
+    session_token?: string;
+    session_jwt?: string;
 }
 export interface OTPEmailSendResponse extends BaseResponse {
     user_id: string;
@@ -24,6 +27,9 @@ export interface SendOTPBySMSRequest {
     phone_number: string;
     expiration_minutes?: number;
     attributes?: Attributes;
+    user_id?: string;
+    session_token?: string;
+    session_jwt?: string;
 }
 export interface SendOTPBySMSResponse extends BaseResponse {
     user_id: string;
@@ -44,6 +50,9 @@ export interface OTPWhatsAppSendRequest {
     phone_number: string;
     expiration_minutes?: number;
     attributes?: Attributes;
+    user_id?: string;
+    session_token?: string;
+    session_jwt?: string;
 }
 export interface OTPWhatsAppSendResponse extends BaseResponse {
     user_id: string;


### PR DESCRIPTION
We have optional user_id, session_token, and session_jwt arguments for magic links email send, OTP email/sms/whatsapp send now to attach the delivery method to a user.