### PR TITLE
[SUP-8] Add locale parameter to Email Magic Links, OTP, and Passwords endpoints

### DIFF
--- a/lib/magic_links.ts
+++ b/lib/magic_links.ts
@@ -13,6 +13,7 @@ export interface SendByEmailRequest {
   user_id?: string;
   session_token?: string;
   session_jwt?: string;
+  locale?: string;
 }
 
 export interface SendByEmailResponse extends BaseResponse {
@@ -29,6 +30,7 @@ export interface LoginOrCreateByEmailRequest {
   create_user_as_pending?: boolean;
   attributes?: Attributes;
   code_challenge?: string;
+  locale?: string;
 }
 
 export interface LoginOrCreateByEmailResponse extends BaseResponse {
@@ -43,6 +45,7 @@ export interface InviteByEmailRequest {
   invite_expiration_minutes?: number;
   name?: Name;
   attributes?: Attributes;
+  locale?: string;
 }
 
 export interface InviteByEmailResponse extends BaseResponse {

--- a/lib/otps.ts
+++ b/lib/otps.ts
@@ -9,6 +9,7 @@ export interface OTPEmailSendRequest {
   user_id?: string;
   session_token?: string;
   session_jwt?: string;
+  locale?: string;
 }
 
 export interface OTPEmailSendResponse extends BaseResponse {
@@ -21,6 +22,7 @@ export interface OTPEmailLoginOrCreateRequest {
   expiration_minutes?: number;
   attributes?: Attributes;
   create_user_as_pending?: boolean;
+  locale?: string;
 }
 
 export interface OTPEmailLoginOrCreateResponse extends BaseResponse {

--- a/lib/otps.ts
+++ b/lib/otps.ts
@@ -38,6 +38,7 @@ export interface SendOTPBySMSRequest {
   user_id?: string;
   session_token?: string;
   session_jwt?: string;
+  locale?: string;
 }
 
 export interface SendOTPBySMSResponse extends BaseResponse {
@@ -50,6 +51,7 @@ export interface LoginOrCreateUserBySMSRequest {
   expiration_minutes?: number;
   attributes?: Attributes;
   create_user_as_pending?: boolean;
+  locale?: string;
 }
 
 export interface LoginOrCreateUserBySMSResponse extends BaseResponse {
@@ -65,6 +67,7 @@ export interface OTPWhatsAppSendRequest {
   user_id?: string;
   session_token?: string;
   session_jwt?: string;
+  locale?: string;
 }
 
 export interface OTPWhatsAppSendResponse extends BaseResponse {
@@ -77,6 +80,7 @@ export interface OTPWhatsAppLoginOrCreateRequest {
   expiration_minutes?: number;
   attributes?: Attributes;
   create_user_as_pending?: boolean;
+  locale?: string;
 }
 
 export interface OTPWhatsAppLoginOrCreateResponse extends BaseResponse {

--- a/lib/passwords.ts
+++ b/lib/passwords.ts
@@ -42,6 +42,7 @@ export interface ResetByEmailStartRequest {
   reset_password_expiration_minutes?: number;
   attributes?: Attributes;
   code_challenge?: string;
+  locale?: string;
 }
 
 export interface ResetByEmailStartResponse extends BaseResponse {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stytch",
-  "version": "5.15.1",
+  "version": "5.16.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "stytch",
-      "version": "5.15.1",
+      "version": "5.16.0",
       "license": "MIT",
       "dependencies": {
         "isomorphic-base64": "^1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stytch",
-  "version": "5.14.0",
+  "version": "5.15.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "stytch",
-      "version": "5.14.0",
+      "version": "5.15.0",
       "license": "MIT",
       "dependencies": {
         "isomorphic-base64": "^1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stytch",
-  "version": "5.15.0",
+  "version": "5.16.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "stytch",
-      "version": "5.15.0",
+      "version": "5.16.0",
       "license": "MIT",
       "dependencies": {
         "isomorphic-base64": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stytch",
-  "version": "5.15.1",
+  "version": "5.16.0",
   "description": "A wrapper for the Stytch API",
   "types": "./types/lib/index.d.ts",
   "main": "./dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stytch",
-  "version": "5.15.0",
+  "version": "5.16.0",
   "description": "A wrapper for the Stytch API",
   "types": "./types/lib/index.d.ts",
   "main": "./dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stytch",
-  "version": "5.14.0",
+  "version": "5.15.0",
   "description": "A wrapper for the Stytch API",
   "types": "./types/lib/index.d.ts",
   "main": "./dist/index.js",

--- a/test/magic_links.test.ts
+++ b/test/magic_links.test.ts
@@ -91,6 +91,7 @@ describe("magicLinks.email.send", () => {
           user_agent: "Toaster/3.0",
           ip_address: "203.0.113.1",
         },
+        locale: "en",
       })
     ).resolves.toMatchObject({
       method: "POST",
@@ -137,6 +138,7 @@ describe("magicLinks.email.loginOrCreate", () => {
           user_agent: "Toaster/3.0",
           ip_address: "203.0.113.1",
         },
+        locale: "en",
       })
     ).resolves.toMatchObject({
       method: "POST",
@@ -181,6 +183,7 @@ describe("magicLinks.email.invite", () => {
           user_agent: "Toaster/3.0",
           ip_address: "203.0.113.1",
         },
+        locale: "en",
       })
     ).resolves.toMatchObject({
       method: "POST",

--- a/test/otps.test.ts
+++ b/test/otps.test.ts
@@ -95,6 +95,7 @@ describe("otps.sms.send", () => {
     return expect(
       otps.sms.send({
         phone_number: "+12025550162",
+        locale: "en",
       })
     ).resolves.toMatchObject({
       method: "POST",
@@ -111,6 +112,7 @@ describe("otps.sms.loginOrCreate", () => {
     return expect(
       otps.sms.loginOrCreate({
         phone_number: "+12025550162",
+        locale: "en",
       })
     ).resolves.toMatchObject({
       method: "POST",
@@ -127,6 +129,7 @@ describe("otps.whatsapp.send", () => {
     return expect(
       otps.whatsapp.send({
         phone_number: "+12025550162",
+        locale: "en",
       })
     ).resolves.toMatchObject({
       method: "POST",
@@ -143,6 +146,7 @@ describe("otps.whatsapp.loginOrCreate", () => {
     return expect(
       otps.whatsapp.loginOrCreate({
         phone_number: "+12025550162",
+        locale: "en",
       })
     ).resolves.toMatchObject({
       method: "POST",

--- a/test/otps.test.ts
+++ b/test/otps.test.ts
@@ -61,6 +61,7 @@ describe("otps.email.send", () => {
     return expect(
       otps.email.send({
         email: "sandbox@stytch.com",
+        locale: "en",
       })
     ).resolves.toMatchObject({
       method: "POST",
@@ -77,6 +78,7 @@ describe("otps.email.loginOrCreate", () => {
     return expect(
       otps.email.loginOrCreate({
         email: "sandbox@stytch.com",
+        locale: "en",
       })
     ).resolves.toMatchObject({
       method: "POST",

--- a/test/password.test.ts
+++ b/test/password.test.ts
@@ -93,6 +93,7 @@ describe("passwords.resetByEmailStart", () => {
       passwords.resetByEmailStart({
         email: "Ada_Lovelace@example.com",
         code_challenge: "exmaple_code_challenge",
+        locale: "en",
       })
     ).resolves.toMatchObject({
       method: "POST",

--- a/types/lib/magic_links.d.ts
+++ b/types/lib/magic_links.d.ts
@@ -11,6 +11,7 @@ export interface SendByEmailRequest {
     user_id?: string;
     session_token?: string;
     session_jwt?: string;
+    locale?: string;
 }
 export interface SendByEmailResponse extends BaseResponse {
     user_id: string;
@@ -25,6 +26,7 @@ export interface LoginOrCreateByEmailRequest {
     create_user_as_pending?: boolean;
     attributes?: Attributes;
     code_challenge?: string;
+    locale?: string;
 }
 export interface LoginOrCreateByEmailResponse extends BaseResponse {
     user_id: string;
@@ -37,6 +39,7 @@ export interface InviteByEmailRequest {
     invite_expiration_minutes?: number;
     name?: Name;
     attributes?: Attributes;
+    locale?: string;
 }
 export interface InviteByEmailResponse extends BaseResponse {
     user_id: string;

--- a/types/lib/otps.d.ts
+++ b/types/lib/otps.d.ts
@@ -32,6 +32,7 @@ export interface SendOTPBySMSRequest {
     user_id?: string;
     session_token?: string;
     session_jwt?: string;
+    locale?: string;
 }
 export interface SendOTPBySMSResponse extends BaseResponse {
     user_id: string;
@@ -42,6 +43,7 @@ export interface LoginOrCreateUserBySMSRequest {
     expiration_minutes?: number;
     attributes?: Attributes;
     create_user_as_pending?: boolean;
+    locale?: string;
 }
 export interface LoginOrCreateUserBySMSResponse extends BaseResponse {
     user_id: string;
@@ -55,6 +57,7 @@ export interface OTPWhatsAppSendRequest {
     user_id?: string;
     session_token?: string;
     session_jwt?: string;
+    locale?: string;
 }
 export interface OTPWhatsAppSendResponse extends BaseResponse {
     user_id: string;
@@ -65,6 +68,7 @@ export interface OTPWhatsAppLoginOrCreateRequest {
     expiration_minutes?: number;
     attributes?: Attributes;
     create_user_as_pending?: boolean;
+    locale?: string;
 }
 export interface OTPWhatsAppLoginOrCreateResponse extends BaseResponse {
     user_id: string;

--- a/types/lib/otps.d.ts
+++ b/types/lib/otps.d.ts
@@ -7,6 +7,7 @@ export interface OTPEmailSendRequest {
     user_id?: string;
     session_token?: string;
     session_jwt?: string;
+    locale?: string;
 }
 export interface OTPEmailSendResponse extends BaseResponse {
     user_id: string;
@@ -17,6 +18,7 @@ export interface OTPEmailLoginOrCreateRequest {
     expiration_minutes?: number;
     attributes?: Attributes;
     create_user_as_pending?: boolean;
+    locale?: string;
 }
 export interface OTPEmailLoginOrCreateResponse extends BaseResponse {
     user_id: string;

--- a/types/lib/passwords.d.ts
+++ b/types/lib/passwords.d.ts
@@ -36,6 +36,7 @@ export interface ResetByEmailStartRequest {
     reset_password_expiration_minutes?: number;
     attributes?: Attributes;
     code_challenge?: string;
+    locale?: string;
 }
 export interface ResetByEmailStartResponse extends BaseResponse {
     user_id: string;


### PR DESCRIPTION
### Description
Adds support for the `locale` parameter for the following endpoints:

- /magic_links/email/send
- /magic_links/email/login_or_create
- /magic_links/email/invite
- /otps/email/send
- /otps/email/login_or_create
- /otps/sms/send
- /otps/sms/login_or_create
- /otps/whatsapp/send
- /otps/whatsapp/login_or_create
- /passwords/email/reset/start

The `locale` parameter specifies the text language of the email that the user receives. Current `locale` options are "en" (English) and "es" (Spanish).
### Dependencies
Support for the `locale` parameter has already been added to Stytch's API endpoints.
### Test coverage
I've added the `locale` parameter to the integration tests for each endpoint.