### PR TITLE
[DEV-594] Remove "Beta" from Passwords product in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ This client library supports all of Stytch's live products:
   - [x] [User Management](https://stytch.com/docs/api/users)
   - [x] [Time-based one-time passcodes (TOTPs)](https://stytch.com/docs/api/totps-overview)
   - [x] [Crypto wallets](https://stytch.com/docs/api/crypto-wallet-overview)
-  - [x] [Passwords (Beta)](https://stytch.com/docs/api/password-overview)
+  - [x] [Passwords](https://stytch.com/docs/api/password-overview)
 
 ### Example usage
 Create an API client:


### PR DESCRIPTION
### Description

Removes "Beta" from in front of the Passwords product in the README.