### PR TITLE
feat: Add support for OAuth Attach endpoint

### DIFF
--- a/dist/oauth.js
+++ b/dist/oauth.js
@@ -33,6 +33,14 @@ class OAuth {
     });
   }
 
+  attach(data) {
+    return (0, _shared.request)(this.fetchConfig, {
+      method: "POST",
+      url: this.endpoint("attach"),
+      data
+    });
+  }
+
 }
 
 exports.OAuth = OAuth;

--- a/lib/oauth.ts
+++ b/lib/oauth.ts
@@ -39,7 +39,7 @@ export interface ProvidersValues {
 export interface AttachRequest {
   provider: string;
 
-  // Exactly one of these user-selection fields must be provided.
+  /** Exactly one of these user-selection fields must be provided. */
   user_id?: string;
   session_token?: string;
   session_jwt?: string;

--- a/lib/oauth.ts
+++ b/lib/oauth.ts
@@ -36,6 +36,19 @@ export interface ProvidersValues {
   scopes: string[];
 }
 
+export interface AttachRequest {
+  provider: string;
+
+  // Exactly one of these user-selection fields must be provided.
+  user_id?: string;
+  session_token?: string;
+  session_jwt?: string;
+}
+
+export interface AttachResponse extends BaseResponse {
+  oauth_attach_token: string;
+}
+
 export class OAuth {
   base_path = "oauth";
 
@@ -62,6 +75,14 @@ export class OAuth {
         ...res,
         user: parseUser(res.user),
       };
+    });
+  }
+
+  attach(data?: AttachRequest): Promise<AttachResponse> {
+    return request<AttachResponse>(this.fetchConfig, {
+      method: "POST",
+      url: this.endpoint("attach"),
+      data,
     });
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stytch",
-  "version": "5.16.0",
+  "version": "5.17.0",
   "description": "A wrapper for the Stytch API",
   "types": "./types/lib/index.d.ts",
   "main": "./dist/index.js",

--- a/types/lib/oauth.d.ts
+++ b/types/lib/oauth.d.ts
@@ -25,10 +25,20 @@ export interface ProvidersValues {
     expires_at?: number;
     scopes: string[];
 }
+export interface AttachRequest {
+    provider: string;
+    user_id?: string;
+    session_token?: string;
+    session_jwt?: string;
+}
+export interface AttachResponse extends BaseResponse {
+    oauth_attach_token: string;
+}
 export declare class OAuth {
     base_path: string;
     private fetchConfig;
     constructor(fetchConfig: fetchConfig);
     private endpoint;
     authenticate(token: string, data?: AuthenticateRequest): Promise<AuthenticateResponse>;
+    attach(data?: AttachRequest): Promise<AttachResponse>;
 }

--- a/types/lib/oauth.d.ts
+++ b/types/lib/oauth.d.ts
@@ -27,6 +27,7 @@ export interface ProvidersValues {
 }
 export interface AttachRequest {
     provider: string;
+    /** Exactly one of these user-selection fields must be provided. */
     user_id?: string;
     session_token?: string;
     session_jwt?: string;


### PR DESCRIPTION
This adds support for an upcoming endpoint: OAuth Attach (`/v1/oauth/attach`).
