### PR TITLE
Add PHPass password hash type

### DIFF
--- a/lib/passwords.ts
+++ b/lib/passwords.ts
@@ -167,7 +167,6 @@ interface PHPassMigrateRequest extends MigrateRequestBase {
   hash_type: "phpass";
 }
 
-
 interface ScryptMigrateRequest extends MigrateRequestBase {
   hash_type: "scrypt";
   scrypt_config?: {

--- a/lib/passwords.ts
+++ b/lib/passwords.ts
@@ -163,6 +163,11 @@ interface SHA1MigrateRequest extends MigrateRequestBase {
   };
 }
 
+interface PHPassMigrateRequest extends MigrateRequestBase {
+  hash_type: "phpass";
+}
+
+
 interface ScryptMigrateRequest extends MigrateRequestBase {
   hash_type: "scrypt";
   scrypt_config?: {
@@ -180,7 +185,8 @@ export type MigrateRequest =
   | Argon2IMigrateRequest
   | Argon2IDMigrateRequest
   | SHA1MigrateRequest
-  | ScryptMigrateRequest;
+  | ScryptMigrateRequest
+  | PHPassMigrateRequest;
 
 export interface MigrateResponse extends BaseResponse {
   user_id: string;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stytch",
-  "version": "5.16.1",
+  "version": "5.18.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "stytch",
-      "version": "5.16.1",
+      "version": "5.18.0",
       "license": "MIT",
       "dependencies": {
         "isomorphic-base64": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stytch",
-  "version": "5.17.0",
+  "version": "5.18.0",
   "description": "A wrapper for the Stytch API",
   "types": "./types/lib/index.d.ts",
   "main": "./dist/index.js",

--- a/test/password.test.ts
+++ b/test/password.test.ts
@@ -194,6 +194,23 @@ describe("passwords.strengthCheck", () => {
 })
 
 describe("passwords.migrate", () => {
+  test("phpass", () => {
+    return expect(
+      passwords.migrate({
+        email: "Ada_Lovelace@example.com",
+        hash_type: "phpass",
+        hash: "not-a-real-password-hash",
+      })
+    ).resolves.toMatchObject({
+      method: "POST",
+      path: "passwords/migrate",
+      data: {
+        email: "Ada_Lovelace@example.com",
+        hash_type: "phpass",
+        hash: "not-a-real-password-hash",
+      },
+    });
+  })
   test("bcrypt", () => {
     return expect(
       passwords.migrate({

--- a/types/lib/passwords.d.ts
+++ b/types/lib/passwords.d.ts
@@ -141,6 +141,9 @@ interface SHA1MigrateRequest extends MigrateRequestBase {
         append_salt?: string;
     };
 }
+interface PHPassMigrateRequest extends MigrateRequestBase {
+    hash_type: "phpass";
+}
 interface ScryptMigrateRequest extends MigrateRequestBase {
     hash_type: "scrypt";
     scrypt_config?: {
@@ -151,7 +154,7 @@ interface ScryptMigrateRequest extends MigrateRequestBase {
         key_length: number;
     };
 }
-export declare type MigrateRequest = MD5MigrateRequest | BcryptMigrateRequest | Argon2IMigrateRequest | Argon2IDMigrateRequest | SHA1MigrateRequest | ScryptMigrateRequest;
+export declare type MigrateRequest = MD5MigrateRequest | BcryptMigrateRequest | Argon2IMigrateRequest | Argon2IDMigrateRequest | SHA1MigrateRequest | ScryptMigrateRequest | PHPassMigrateRequest;
 export interface MigrateResponse extends BaseResponse {
     user_id: string;
     email_id: string;


### PR DESCRIPTION
This adds support for `phpass` hashes in the Password Migrate endpoint