### PR TITLE
dev: Update sandbox test error URL expectations

### DIFF
--- a/test/sandbox.test.ts
+++ b/test/sandbox.test.ts
@@ -54,7 +54,7 @@ describeIf(
               "The magic link could not be authenticated because it was either already used or expired. Send another magic link to this user."
             );
             expect(err.error_url).toEqual(
-              "https://stytch.com/docs/api/errors/401"
+              "https://stytch.com/docs/api/errors/401/unable_to_auth_magic_link"
             );
           });
       });
@@ -69,7 +69,7 @@ describeIf(
               "The magic link could not be authenticated, try sending another magic link to the user."
             );
             expect(err.error_url).toEqual(
-              "https://stytch.com/docs/api/errors/404"
+              "https://stytch.com/docs/api/errors/404/magic_link_not_found"
             );
           });
       });


### PR DESCRIPTION
We recently started including the error code in the URL for direct links to error message descriptions. This updates the test expectations to match the new format.

No version bump needed because this won't be released on its own.
