### PR TITLE
fix: Replace Isomorphic Base64 with b64-lite

### DIFF
--- a/dist/client.js
+++ b/dist/client.js
@@ -5,7 +5,7 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.Client = void 0;
 
-var _isomorphicBase = require("isomorphic-base64");
+var _b64Lite = require("b64-lite");
 
 var jose = _interopRequireWildcard(require("jose"));
 
@@ -61,7 +61,7 @@ class Client {
     const headers = {
       "Content-Type": "application/json",
       "User-Agent": `Stytch Node v${_package.version}`,
-      Authorization: "Basic " + (0, _isomorphicBase.btoa)(config.project_id + ":" + config.secret)
+      Authorization: "Basic " + (0, _b64Lite.btoa)(config.project_id + ":" + config.secret)
     };
     this.fetchConfig = {
       baseURL: config.env,

--- a/lib/base64.d.ts
+++ b/lib/base64.d.ts
@@ -1,4 +1,3 @@
-declare module "isomorphic-base64" {
-  export function atob(str: string): string;
+declare module "b64-lite" {
   export function btoa(str: string): string;
 }

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -1,5 +1,5 @@
 import * as http from "http";
-import { btoa } from "isomorphic-base64";
+import { btoa } from "b64-lite";
 import * as jose from "jose";
 import { version } from "../package.json";
 import { CryptoWallets } from "./crypto_wallets";

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "5.18.1",
       "license": "MIT",
       "dependencies": {
-        "isomorphic-base64": "^1.0.2",
+        "b64-lite": "^1.4.0",
         "isomorphic-unfetch": "^3.1.0",
         "jose": "^4.6.0"
       },
@@ -2775,6 +2775,14 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true
     },
+    "node_modules/b64-lite": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/b64-lite/-/b64-lite-1.4.0.tgz",
+      "integrity": "sha512-aHe97M7DXt+dkpa8fHlCcm1CnskAHrJqEfMI0KN7dwqlzml/aUe1AGt6lk51HzrSfVD67xOso84sOpr+0wIe2w==",
+      "dependencies": {
+        "base-64": "^0.1.0"
+      }
+    },
     "node_modules/babel-jest": {
       "version": "27.2.4",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-27.2.4.tgz",
@@ -2920,6 +2928,11 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
+    },
+    "node_modules/base-64": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/base-64/-/base-64-0.1.0.tgz",
+      "integrity": "sha512-Y5gU45svrR5tI2Vt/X9GPd3L0HNIKzGu202EjxrXMpuc2V2CiKgemAbUUsqYmZJvPtCXoUKjNZwBJzsNScUbXA=="
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -4419,11 +4432,6 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
-    },
-    "node_modules/isomorphic-base64": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/isomorphic-base64/-/isomorphic-base64-1.0.2.tgz",
-      "integrity": "sha1-9Caq6CVpuopOxcpzrSGkSrHueAM="
     },
     "node_modules/isomorphic-unfetch": {
       "version": "3.1.0",
@@ -6707,6 +6715,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz",
       "integrity": "sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==",
+      "deprecated": "Use your platform's native performance.now() and performance.timeOrigin.",
       "dev": true,
       "dependencies": {
         "browser-process-hrtime": "^1.0.0"
@@ -8898,6 +8907,14 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true
     },
+    "b64-lite": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/b64-lite/-/b64-lite-1.4.0.tgz",
+      "integrity": "sha512-aHe97M7DXt+dkpa8fHlCcm1CnskAHrJqEfMI0KN7dwqlzml/aUe1AGt6lk51HzrSfVD67xOso84sOpr+0wIe2w==",
+      "requires": {
+        "base-64": "^0.1.0"
+      }
+    },
     "babel-jest": {
       "version": "27.2.4",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-27.2.4.tgz",
@@ -9013,6 +9030,11 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
+    },
+    "base-64": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/base-64/-/base-64-0.1.0.tgz",
+      "integrity": "sha512-Y5gU45svrR5tI2Vt/X9GPd3L0HNIKzGu202EjxrXMpuc2V2CiKgemAbUUsqYmZJvPtCXoUKjNZwBJzsNScUbXA=="
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -10160,11 +10182,6 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
-    },
-    "isomorphic-base64": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/isomorphic-base64/-/isomorphic-base64-1.0.2.tgz",
-      "integrity": "sha1-9Caq6CVpuopOxcpzrSGkSrHueAM="
     },
     "isomorphic-unfetch": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "typescript": "^4.4.3"
   },
   "dependencies": {
-    "isomorphic-base64": "^1.0.2",
+    "b64-lite": "^1.4.0",
     "isomorphic-unfetch": "^3.1.0",
     "jose": "^4.6.0"
   },


### PR DESCRIPTION
Replaces https://github.com/ksheedlo/isomorphic-base64 with https://github.com/kevlened/b64-lite - the former has had a PR open to [fix Buffer deprecation warnings](https://github.com/ksheedlo/isomorphic-base64/pull/2) for several years and looks abandoned.

Fixes #171 