### PR TITLE
chore: Run integration tests in all supported node versions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,12 +22,15 @@ jobs:
   integration-test:
     name: Run Integration Tests
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        version: [14, 16, 18]
     environment: integration_tests
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: "16"
+          node-version: ${{ matrix.version }}
       - run: npm ci
       - run: npm test
         env:


### PR DESCRIPTION
Runs integration tests in all supported node versions, not just 16