### PR TITLE
fix: Do not depend on an external base64 package anymore

### DIFF
--- a/dist/base64.d.js
+++ b/dist/base64.d.js
@@ -1,1 +1,0 @@
-"use strict";

--- a/dist/shared/base64.js
+++ b/dist/shared/base64.js
@@ -1,0 +1,59 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.base64Encode = base64Encode;
+const LOOKUP_TABLE = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=";
+/**
+ * base64Encode is a vanilla-javascript implementation of base64 encoding
+ * We expect stytch-node to be run in a variety of runtimes, so
+ * we often can't depend on `window.atob` or `new Buffer`.
+ *
+ * We've experienced problems with two isomorphic base64 libraries so far,
+ * so let's just roll our own!
+ *
+ * We only use this to encode project IDs and secrets, which are guaranteed to be ASCII and not unicode.
+ *
+ * Heavily, heavily inspired by http://www.webtoolkit.info/javascript-base64.html
+ * @param input string
+ */
+
+function base64Encode(input) {
+  let output = ""; // Unicode sanity check
+
+  for (let i = 0; i < input.length; i++) {
+    if (input.charCodeAt(i) > 128) {
+      throw Error("Base64 encoded unicode is not supported. Cannot encode " + input);
+    }
+  }
+
+  let char1 = 0,
+      char2 = 0,
+      char3 = 0;
+  let enc1 = 0,
+      enc2 = 0,
+      enc3 = 0,
+      enc4 = 0;
+  let i = 0;
+
+  while (i < input.length) {
+    char1 = input.charCodeAt(i++);
+    char2 = input.charCodeAt(i++);
+    char3 = input.charCodeAt(i++);
+    enc1 = char1 >> 2;
+    enc2 = (char1 & 3) << 4 | char2 >> 4;
+    enc3 = (char2 & 15) << 2 | char3 >> 6;
+    enc4 = char3 & 63;
+
+    if (isNaN(char2)) {
+      enc3 = enc4 = 64;
+    } else if (isNaN(char3)) {
+      enc4 = 64;
+    }
+
+    output = output + LOOKUP_TABLE.charAt(enc1) + LOOKUP_TABLE.charAt(enc2) + LOOKUP_TABLE.charAt(enc3) + LOOKUP_TABLE.charAt(enc4);
+  }
+
+  return output;
+}

--- a/dist/shared/client.js
+++ b/dist/shared/client.js
@@ -9,9 +9,9 @@ var envs = _interopRequireWildcard(require("./envs"));
 
 var _package = require("../../package.json");
 
-var _b64Lite = require("b64-lite");
-
 var jose = _interopRequireWildcard(require("jose"));
+
+var _base = require("./base64");
 
 function _getRequireWildcardCache(nodeInterop) { if (typeof WeakMap !== "function") return null; var cacheBabelInterop = new WeakMap(); var cacheNodeInterop = new WeakMap(); return (_getRequireWildcardCache = function (nodeInterop) { return nodeInterop ? cacheNodeInterop : cacheBabelInterop; })(nodeInterop); }
 
@@ -43,7 +43,7 @@ class BaseClient {
     const headers = {
       "Content-Type": "application/json",
       "User-Agent": `Stytch Node v${_package.version}`,
-      Authorization: "Basic " + (0, _b64Lite.btoa)(config.project_id + ":" + config.secret)
+      Authorization: "Basic " + (0, _base.base64Encode)(config.project_id + ":" + config.secret)
     };
     this.fetchConfig = {
       baseURL: config.env,

--- a/lib/base64.d.ts
+++ b/lib/base64.d.ts
@@ -1,3 +1,0 @@
-declare module "b64-lite" {
-  export function btoa(str: string): string;
-}

--- a/lib/shared/base64.ts
+++ b/lib/shared/base64.ts
@@ -1,0 +1,52 @@
+const LOOKUP_TABLE = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=";
+
+/**
+ * base64Encode is a vanilla-javascript implementation of base64 encoding
+ * We expect stytch-node to be run in a variety of runtimes, so
+ * we often can't depend on `window.atob` or `new Buffer`.
+ *
+ * We've experienced problems with two isomorphic base64 libraries so far,
+ * so let's just roll our own!
+ *
+ * We only use this to encode project IDs and secrets, which are guaranteed to be ASCII and not unicode.
+ *
+ * Heavily, heavily inspired by http://www.webtoolkit.info/javascript-base64.html
+ * @param input string
+ */
+export function base64Encode(input: string): string {
+  let output = "";
+
+  // Unicode sanity check
+  for (let i = 0; i < input.length; i++) {
+    if (input.charCodeAt(i) > 128) {
+      throw Error("Base64 encoded unicode is not supported. Cannot encode " + input);
+    }
+  }
+
+  let char1 = 0, char2 = 0, char3 = 0;
+  let enc1 = 0, enc2 = 0, enc3 = 0, enc4 = 0;
+
+  let i = 0;
+
+  while (i < input.length) {
+    char1 = input.charCodeAt(i++);
+    char2 = input.charCodeAt(i++);
+    char3 = input.charCodeAt(i++);
+
+    enc1 = char1 >> 2;
+    enc2 = ((char1 & 3) << 4) | (char2 >> 4);
+    enc3 = ((char2 & 15) << 2) | (char3 >> 6);
+    enc4 = char3 & 63;
+
+    if (isNaN(char2)) {
+      enc3 = enc4 = 64;
+    } else if (isNaN(char3)) {
+      enc4 = 64;
+    }
+
+    output = output +
+      LOOKUP_TABLE.charAt(enc1) + LOOKUP_TABLE.charAt(enc2) +
+      LOOKUP_TABLE.charAt(enc3) + LOOKUP_TABLE.charAt(enc4);
+  }
+  return output;
+}

--- a/lib/shared/base64.ts
+++ b/lib/shared/base64.ts
@@ -1,4 +1,5 @@
-const LOOKUP_TABLE = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=";
+const LOOKUP_TABLE =
+  "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=";
 
 /**
  * base64Encode is a vanilla-javascript implementation of base64 encoding
@@ -19,12 +20,19 @@ export function base64Encode(input: string): string {
   // Unicode sanity check
   for (let i = 0; i < input.length; i++) {
     if (input.charCodeAt(i) > 128) {
-      throw Error("Base64 encoded unicode is not supported. Cannot encode " + input);
+      throw Error(
+        "Base64 encoded unicode is not supported. Cannot encode " + input
+      );
     }
   }
 
-  let char1 = 0, char2 = 0, char3 = 0;
-  let enc1 = 0, enc2 = 0, enc3 = 0, enc4 = 0;
+  let char1 = 0,
+    char2 = 0,
+    char3 = 0;
+  let enc1 = 0,
+    enc2 = 0,
+    enc3 = 0,
+    enc4 = 0;
 
   let i = 0;
 
@@ -44,9 +52,12 @@ export function base64Encode(input: string): string {
       enc4 = 64;
     }
 
-    output = output +
-      LOOKUP_TABLE.charAt(enc1) + LOOKUP_TABLE.charAt(enc2) +
-      LOOKUP_TABLE.charAt(enc3) + LOOKUP_TABLE.charAt(enc4);
+    output =
+      output +
+      LOOKUP_TABLE.charAt(enc1) +
+      LOOKUP_TABLE.charAt(enc2) +
+      LOOKUP_TABLE.charAt(enc3) +
+      LOOKUP_TABLE.charAt(enc4);
   }
   return output;
 }

--- a/lib/shared/client.ts
+++ b/lib/shared/client.ts
@@ -47,7 +47,8 @@ export class BaseClient {
     const headers = {
       "Content-Type": "application/json",
       "User-Agent": `Stytch Node v${version}`,
-      Authorization: "Basic " + base64Encode(config.project_id + ":" + config.secret),
+      Authorization:
+        "Basic " + base64Encode(config.project_id + ":" + config.secret),
     };
 
     this.fetchConfig = {

--- a/lib/shared/client.ts
+++ b/lib/shared/client.ts
@@ -1,10 +1,10 @@
 import * as http from "http";
 import * as envs from "./envs";
 import { version } from "../../package.json";
-import { btoa } from "b64-lite";
 import { fetchConfig } from ".";
 import * as jose from "jose";
 import { JwtConfig } from "./sessions";
+import { base64Encode } from "./base64";
 
 const DEFAULT_TIMEOUT = 10 * 60 * 1000; // Ten minutes
 
@@ -47,7 +47,7 @@ export class BaseClient {
     const headers = {
       "Content-Type": "application/json",
       "User-Agent": `Stytch Node v${version}`,
-      Authorization: "Basic " + btoa(config.project_id + ":" + config.secret),
+      Authorization: "Basic " + base64Encode(config.project_id + ":" + config.secret),
     };
 
     this.fetchConfig = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "6.0.0",
       "license": "MIT",
       "dependencies": {
-        "b64-lite": "^1.4.0",
         "isomorphic-unfetch": "^3.1.0",
         "jose": "^4.6.0"
       },
@@ -2775,14 +2774,6 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true
     },
-    "node_modules/b64-lite": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/b64-lite/-/b64-lite-1.4.0.tgz",
-      "integrity": "sha512-aHe97M7DXt+dkpa8fHlCcm1CnskAHrJqEfMI0KN7dwqlzml/aUe1AGt6lk51HzrSfVD67xOso84sOpr+0wIe2w==",
-      "dependencies": {
-        "base-64": "^0.1.0"
-      }
-    },
     "node_modules/babel-jest": {
       "version": "27.2.4",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-27.2.4.tgz",
@@ -2928,11 +2919,6 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
-    },
-    "node_modules/base-64": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/base-64/-/base-64-0.1.0.tgz",
-      "integrity": "sha512-Y5gU45svrR5tI2Vt/X9GPd3L0HNIKzGu202EjxrXMpuc2V2CiKgemAbUUsqYmZJvPtCXoUKjNZwBJzsNScUbXA=="
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -8907,14 +8893,6 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true
     },
-    "b64-lite": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/b64-lite/-/b64-lite-1.4.0.tgz",
-      "integrity": "sha512-aHe97M7DXt+dkpa8fHlCcm1CnskAHrJqEfMI0KN7dwqlzml/aUe1AGt6lk51HzrSfVD67xOso84sOpr+0wIe2w==",
-      "requires": {
-        "base-64": "^0.1.0"
-      }
-    },
     "babel-jest": {
       "version": "27.2.4",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-27.2.4.tgz",
@@ -9030,11 +9008,6 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
-    },
-    "base-64": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/base-64/-/base-64-0.1.0.tgz",
-      "integrity": "sha512-Y5gU45svrR5tI2Vt/X9GPd3L0HNIKzGu202EjxrXMpuc2V2CiKgemAbUUsqYmZJvPtCXoUKjNZwBJzsNScUbXA=="
     },
     "brace-expansion": {
       "version": "1.1.11",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stytch",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "stytch",
-      "version": "6.0.0",
+      "version": "6.0.1",
       "license": "MIT",
       "dependencies": {
         "isomorphic-unfetch": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "typescript": "^4.4.3"
   },
   "dependencies": {
-    "b64-lite": "^1.4.0",
     "isomorphic-unfetch": "^3.1.0",
     "jose": "^4.6.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stytch",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "description": "A wrapper for the Stytch API",
   "types": "./types/lib/index.d.ts",
   "main": "./dist/index.js",

--- a/test/shared/base64.test.ts
+++ b/test/shared/base64.test.ts
@@ -1,0 +1,38 @@
+import { base64Encode } from "../../lib/shared/base64";
+import { randomBytes, randomUUID } from "crypto";
+
+describe("base64Encode", () => {
+  test("Successfully encodes a project ID and secret for basic auth", () => {
+
+    const project_id = "project-live-c60c0abe-c25a-4472-a9ed-320c6667d317";
+    const secret = "secret-live-80JASucyk7z_G8Z-7dVwZVGXL5NT_qGAQ2I=";
+    const header = project_id + ":" + secret;
+
+    const expected = Buffer.from(header).toString("base64");
+    const encoded = base64Encode(header);
+
+    expect(encoded).toEqual(expected);
+  });
+
+  test("Successfully encodes a variety of inputs", () => {
+    const inputs = [];
+
+    for (let i = 0; i < 200; i++) {
+      inputs.push(randomUUID());
+      inputs.push(randomBytes(20).toString("hex"));
+      inputs.push(randomBytes(20).toString("ascii"));
+      inputs.push(randomBytes(20).toString("base64"));
+      inputs.push(randomBytes(20).toString("base64url"));
+    }
+
+    for (const input of inputs) {
+      const expected = Buffer.from(input).toString("base64");
+      const encoded = base64Encode(input);
+      expect(encoded).toEqual(expected);
+    }
+  });
+
+  test("Throws an error when given unicode input", () => {
+    expect(() => base64Encode("😅")).toThrow("Base64 encoded unicode is not supported. Cannot encode 😅");
+  });
+});

--- a/test/shared/base64.test.ts
+++ b/test/shared/base64.test.ts
@@ -3,7 +3,6 @@ import { randomBytes, randomUUID } from "crypto";
 
 describe("base64Encode", () => {
   test("Successfully encodes a project ID and secret for basic auth", () => {
-
     const project_id = "project-live-c60c0abe-c25a-4472-a9ed-320c6667d317";
     const secret = "secret-live-80JASucyk7z_G8Z-7dVwZVGXL5NT_qGAQ2I=";
     const header = project_id + ":" + secret;
@@ -33,6 +32,8 @@ describe("base64Encode", () => {
   });
 
   test("Throws an error when given unicode input", () => {
-    expect(() => base64Encode("😅")).toThrow("Base64 encoded unicode is not supported. Cannot encode 😅");
+    expect(() => base64Encode("😅")).toThrow(
+      "Base64 encoded unicode is not supported. Cannot encode 😅"
+    );
   });
 });

--- a/types/lib/shared/base64.d.ts
+++ b/types/lib/shared/base64.d.ts
@@ -1,0 +1,14 @@
+/**
+ * base64Encode is a vanilla-javascript implementation of base64 encoding
+ * We expect stytch-node to be run in a variety of runtimes, so
+ * we often can't depend on `window.atob` or `new Buffer`.
+ *
+ * We've experienced problems with two isomorphic base64 libraries so far,
+ * so let's just roll our own!
+ *
+ * We only use this to encode project IDs and secrets, which are guaranteed to be ASCII and not unicode.
+ *
+ * Heavily, heavily inspired by http://www.webtoolkit.info/javascript-base64.html
+ * @param input string
+ */
+export declare function base64Encode(input: string): string;


### PR DESCRIPTION
#185 is causing issues in NextJS edge middleware runtimes - see #191 

Let's stop depending on external base64 packages and just do it in vanilla JS. 