### PR TITLE
Add new LUDS options to StrengthCheckResponse

### DIFF
--- a/lib/b2c/passwords.ts
+++ b/lib/b2c/passwords.ts
@@ -110,9 +110,19 @@ export interface StrengthCheckResponse extends BaseResponse {
   valid_password: boolean;
   score: number;
   breached_password: boolean;
+  strength_policy: string;
+  breach_detection_on_create: boolean;
   feedback: {
     suggestions: string[];
     warning: string;
+    luds_requirements: {
+      has_lower_case: boolean;
+      has_upper_case: boolean;
+      has_digit: boolean;
+      has_symbol: boolean;
+      missing_complexity: number;
+      missing_characters: number;
+    };
   };
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stytch",
-  "version": "6.1.1",
+  "version": "6.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "stytch",
-      "version": "6.1.1",
+      "version": "6.1.2",
       "license": "MIT",
       "dependencies": {
         "isomorphic-unfetch": "^3.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stytch",
-  "version": "6.1.2",
+  "version": "6.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "stytch",
-      "version": "6.1.2",
+      "version": "6.0.2",
       "license": "MIT",
       "dependencies": {
         "isomorphic-unfetch": "^3.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stytch",
-  "version": "6.0.1",
+  "version": "6.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "stytch",
-      "version": "6.0.1",
+      "version": "6.1.0",
       "license": "MIT",
       "dependencies": {
         "isomorphic-unfetch": "^3.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stytch",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "stytch",
-      "version": "6.1.0",
+      "version": "6.1.1",
       "license": "MIT",
       "dependencies": {
         "isomorphic-unfetch": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stytch",
-  "version": "6.1.1",
+  "version": "6.1.2",
   "description": "A wrapper for the Stytch API",
   "types": "./types/lib/index.d.ts",
   "main": "./dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stytch",
-  "version": "6.0.2",
+  "version": "6.1.0",
   "description": "A wrapper for the Stytch API",
   "types": "./types/lib/index.d.ts",
   "main": "./dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stytch",
-  "version": "6.1.2",
+  "version": "6.0.1",
   "description": "A wrapper for the Stytch API",
   "types": "./types/lib/index.d.ts",
   "main": "./dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stytch",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "description": "A wrapper for the Stytch API",
   "types": "./types/lib/index.d.ts",
   "main": "./dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stytch",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "description": "A wrapper for the Stytch API",
   "types": "./types/lib/index.d.ts",
   "main": "./dist/index.js",

--- a/types/lib/b2c/passwords.d.ts
+++ b/types/lib/b2c/passwords.d.ts
@@ -96,9 +96,19 @@ export interface StrengthCheckResponse extends BaseResponse {
     valid_password: boolean;
     score: number;
     breached_password: boolean;
+    strength_policy: string;
+    breach_detection_on_create: boolean;
     feedback: {
         suggestions: string[];
         warning: string;
+        luds_requirements: {
+            has_lower_case: boolean;
+            has_upper_case: boolean;
+            has_digit: boolean;
+            has_symbol: boolean;
+            missing_complexity: number;
+            missing_characters: number;
+        };
     };
 }
 interface MigrateRequestBase {


### PR DESCRIPTION
## Overview
Adding the new password config options to `StrengthCheckResponse` to match [proto here](https://github.com/stytchauth/protobuf/blob/0d242bb6a7ae63f91a12fe8049a8e748977e2c0b/api/password/v1/password.proto#L172-L195)

I've never used node before, plz send help