### PR TITLE
include "types" in module exports (#174)

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "main": "./dist/index.js",
   "exports": {
     "require": "./dist/index.js",
-    "import": "./module.mjs"
+    "import": "./module.mjs",
+    "types": "./types/lib/index.d.ts"
   },
   "files": [
     "dist/**/*",


### PR DESCRIPTION
using modern `moduleResolution` strategies fails without it

closes #174