### PR TITLE
Add statuses plural filter for member search

### DIFF
--- a/lib/b2b/members.ts
+++ b/lib/b2b/members.ts
@@ -45,8 +45,8 @@ export type MemberSearchOperand =
       filter_value: string;
     }
   | {
-      filter_name: "status";
-      filter_value: "active" | "pending";
+      filter_name: "statuses";
+      filter_value: string[];
     };
 
 export interface SearchOrganizationMemberRequest {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stytch",
-  "version": "6.0.2",
+  "version": "6.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "stytch",
-      "version": "6.0.2",
+      "version": "6.0.3",
       "license": "MIT",
       "dependencies": {
         "isomorphic-unfetch": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stytch",
-  "version": "6.0.2",
+  "version": "6.0.3",
   "description": "A wrapper for the Stytch API",
   "types": "./types/lib/index.d.ts",
   "main": "./dist/index.js",

--- a/test/b2b/members.test.ts
+++ b/test/b2b/members.test.ts
@@ -89,6 +89,7 @@ describe("members.search", () => {
             operator: SearchOperator.OR,
             operands: [
               { filter_name: "member_ids", filter_value: ["member-id-1234"] },
+              { filter_name: "statuses", filter_value: ["active", "invited"] }
             ],
           },
         },
@@ -118,6 +119,7 @@ describe("members.search", () => {
           operator: SearchOperator.OR,
           operands: [
             { filter_name: "member_ids", filter_value: ["member-id-1234"] },
+            { filter_name: "statuses", filter_value: ["active", "invited"] }
           ],
         },
       })

--- a/test/b2b/members.test.ts
+++ b/test/b2b/members.test.ts
@@ -89,7 +89,7 @@ describe("members.search", () => {
             operator: SearchOperator.OR,
             operands: [
               { filter_name: "member_ids", filter_value: ["member-id-1234"] },
-              { filter_name: "statuses", filter_value: ["active", "invited"] }
+              { filter_name: "statuses", filter_value: ["active", "invited"] },
             ],
           },
         },
@@ -119,7 +119,7 @@ describe("members.search", () => {
           operator: SearchOperator.OR,
           operands: [
             { filter_name: "member_ids", filter_value: ["member-id-1234"] },
-            { filter_name: "statuses", filter_value: ["active", "invited"] }
+            { filter_name: "statuses", filter_value: ["active", "invited"] },
           ],
         },
       })

--- a/types/lib/b2b/members.d.ts
+++ b/types/lib/b2b/members.d.ts
@@ -36,8 +36,8 @@ export declare type MemberSearchOperand = {
     filter_name: "member_email_fuzzy";
     filter_value: string;
 } | {
-    filter_name: "status";
-    filter_value: "active" | "pending";
+    filter_name: "statuses";
+    filter_value: string[];
 };
 export interface SearchOrganizationMemberRequest {
     organization_ids: string[];


### PR DESCRIPTION
Replaces the old singular `status` filter for member search with the plural `statuses`, which will take in an array of strings