### PR TITLE
fix: Use B2B JWKS endpoint for B2B projects

### DIFF
--- a/dist/b2b/client.js
+++ b/dist/b2b/client.js
@@ -15,6 +15,12 @@ var _sso = require("./sso");
 
 var _client = require("../shared/client");
 
+var jose = _interopRequireWildcard(require("jose"));
+
+function _getRequireWildcardCache(nodeInterop) { if (typeof WeakMap !== "function") return null; var cacheBabelInterop = new WeakMap(); var cacheNodeInterop = new WeakMap(); return (_getRequireWildcardCache = function (nodeInterop) { return nodeInterop ? cacheNodeInterop : cacheBabelInterop; })(nodeInterop); }
+
+function _interopRequireWildcard(obj, nodeInterop) { if (!nodeInterop && obj && obj.__esModule) { return obj; } if (obj === null || typeof obj !== "object" && typeof obj !== "function") { return { default: obj }; } var cache = _getRequireWildcardCache(nodeInterop); if (cache && cache.has(obj)) { return cache.get(obj); } var newObj = {}; var hasPropertyDescriptor = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var key in obj) { if (key !== "default" && Object.prototype.hasOwnProperty.call(obj, key)) { var desc = hasPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : null; if (desc && (desc.get || desc.set)) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } newObj.default = obj; if (cache) { cache.set(obj, newObj); } return newObj; }
+
 class B2BClient extends _client.BaseClient {
   constructor(config) {
     super(config);
@@ -23,6 +29,12 @@ class B2BClient extends _client.BaseClient {
       this.fetchConfig.baseURL += "b2b/";
     }
 
+    this.jwtConfig = {
+      // Only allow JWTs that were meant for this project.
+      projectID: config.project_id,
+      // Fetch the signature verification keys for this project as needed.
+      jwks: jose.createRemoteJWKSet(new URL(`sessions/jwks/${config.project_id}`, this.fetchConfig.baseURL))
+    };
     this.magicLinks = new _magic_links.MagicLinks(this.fetchConfig);
     this.sessions = new _sessions.Sessions(this.fetchConfig, this.jwtConfig);
     this.organizations = new _organizations.Organizations(this.fetchConfig);

--- a/dist/b2c/client.js
+++ b/dist/b2c/client.js
@@ -25,9 +25,21 @@ var _webauthn = require("./webauthn");
 
 var _client = require("../shared/client");
 
+var jose = _interopRequireWildcard(require("jose"));
+
+function _getRequireWildcardCache(nodeInterop) { if (typeof WeakMap !== "function") return null; var cacheBabelInterop = new WeakMap(); var cacheNodeInterop = new WeakMap(); return (_getRequireWildcardCache = function (nodeInterop) { return nodeInterop ? cacheNodeInterop : cacheBabelInterop; })(nodeInterop); }
+
+function _interopRequireWildcard(obj, nodeInterop) { if (!nodeInterop && obj && obj.__esModule) { return obj; } if (obj === null || typeof obj !== "object" && typeof obj !== "function") { return { default: obj }; } var cache = _getRequireWildcardCache(nodeInterop); if (cache && cache.has(obj)) { return cache.get(obj); } var newObj = {}; var hasPropertyDescriptor = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var key in obj) { if (key !== "default" && Object.prototype.hasOwnProperty.call(obj, key)) { var desc = hasPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : null; if (desc && (desc.get || desc.set)) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } newObj.default = obj; if (cache) { cache.set(obj, newObj); } return newObj; }
+
 class Client extends _client.BaseClient {
   constructor(config) {
     super(config);
+    this.jwtConfig = {
+      // Only allow JWTs that were meant for this project.
+      projectID: config.project_id,
+      // Fetch the signature verification keys for this project as needed.
+      jwks: jose.createRemoteJWKSet(new URL(`sessions/jwks/${config.project_id}`, this.fetchConfig.baseURL))
+    };
     this.users = new _users.Users(this.fetchConfig);
     this.magicLinks = new _magic_links.MagicLinks(this.fetchConfig);
     this.oauth = new _oauth.OAuth(this.fetchConfig);

--- a/dist/shared/client.js
+++ b/dist/shared/client.js
@@ -9,8 +9,6 @@ var envs = _interopRequireWildcard(require("./envs"));
 
 var _package = require("../../package.json");
 
-var jose = _interopRequireWildcard(require("jose"));
-
 var _base = require("./base64");
 
 function _getRequireWildcardCache(nodeInterop) { if (typeof WeakMap !== "function") return null; var cacheBabelInterop = new WeakMap(); var cacheNodeInterop = new WeakMap(); return (_getRequireWildcardCache = function (nodeInterop) { return nodeInterop ? cacheNodeInterop : cacheBabelInterop; })(nodeInterop); }
@@ -57,13 +55,6 @@ class BaseClient {
     if (!this.baseURL.endsWith("/")) {
       this.baseURL += "/";
     }
-
-    this.jwtConfig = {
-      // Only allow JWTs that were meant for this project.
-      projectID: config.project_id,
-      // Fetch the signature verification keys for this project as needed.
-      jwks: jose.createRemoteJWKSet(new URL(`sessions/jwks/${config.project_id}`, this.baseURL))
-    };
   }
 
 }

--- a/lib/b2b/client.ts
+++ b/lib/b2b/client.ts
@@ -3,8 +3,11 @@ import { Sessions } from "./sessions";
 import { Organizations } from "./organizations";
 import { SSO } from "./sso";
 import { BaseClient, ClientConfig } from "../shared/client";
+import * as jose from "jose";
+import { JwtConfig } from "../shared/sessions";
 
 export class B2BClient extends BaseClient {
+  protected jwtConfig: JwtConfig;
   magicLinks: MagicLinks;
   sessions: Sessions;
   organizations: Organizations;
@@ -16,6 +19,15 @@ export class B2BClient extends BaseClient {
     if (!this.fetchConfig.baseURL.endsWith("b2b/")) {
       this.fetchConfig.baseURL += "b2b/";
     }
+
+    this.jwtConfig = {
+      // Only allow JWTs that were meant for this project.
+      projectID: config.project_id,
+      // Fetch the signature verification keys for this project as needed.
+      jwks: jose.createRemoteJWKSet(
+        new URL(`sessions/jwks/${config.project_id}`, this.fetchConfig.baseURL)
+      ),
+    };
 
     this.magicLinks = new MagicLinks(this.fetchConfig);
     this.sessions = new Sessions(this.fetchConfig, this.jwtConfig);

--- a/lib/b2c/client.ts
+++ b/lib/b2c/client.ts
@@ -8,8 +8,11 @@ import { TOTPs } from "./totps";
 import { Users } from "./users";
 import { WebAuthn } from "./webauthn";
 import { BaseClient, ClientConfig } from "../shared/client";
+import * as jose from "jose";
+import { JwtConfig } from "../shared/sessions";
 
 export class Client extends BaseClient {
+  protected jwtConfig: JwtConfig;
   users: Users;
   magicLinks: MagicLinks;
   otps: OTPs;
@@ -22,6 +25,15 @@ export class Client extends BaseClient {
 
   constructor(config: ClientConfig) {
     super(config);
+
+    this.jwtConfig = {
+      // Only allow JWTs that were meant for this project.
+      projectID: config.project_id,
+      // Fetch the signature verification keys for this project as needed.
+      jwks: jose.createRemoteJWKSet(
+        new URL(`sessions/jwks/${config.project_id}`, this.fetchConfig.baseURL)
+      ),
+    };
 
     this.users = new Users(this.fetchConfig);
     this.magicLinks = new MagicLinks(this.fetchConfig);

--- a/lib/shared/client.ts
+++ b/lib/shared/client.ts
@@ -2,8 +2,6 @@ import * as http from "http";
 import * as envs from "./envs";
 import { version } from "../../package.json";
 import { fetchConfig } from ".";
-import * as jose from "jose";
-import { JwtConfig } from "./sessions";
 import { base64Encode } from "./base64";
 
 const DEFAULT_TIMEOUT = 10 * 60 * 1000; // Ten minutes
@@ -19,7 +17,6 @@ export interface ClientConfig {
 export class BaseClient {
   protected fetchConfig: fetchConfig;
   protected baseURL: string;
-  protected jwtConfig: JwtConfig;
 
   constructor(config: ClientConfig) {
     if (typeof config != "object") {
@@ -63,14 +60,5 @@ export class BaseClient {
     if (!this.baseURL.endsWith("/")) {
       this.baseURL += "/";
     }
-
-    this.jwtConfig = {
-      // Only allow JWTs that were meant for this project.
-      projectID: config.project_id,
-      // Fetch the signature verification keys for this project as needed.
-      jwks: jose.createRemoteJWKSet(
-        new URL(`sessions/jwks/${config.project_id}`, this.baseURL)
-      ),
-    };
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stytch",
-  "version": "6.0.3",
+  "version": "6.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "stytch",
-      "version": "6.0.3",
+      "version": "6.0.4",
       "license": "MIT",
       "dependencies": {
         "isomorphic-unfetch": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stytch",
-  "version": "6.0.3",
+  "version": "6.0.4",
   "description": "A wrapper for the Stytch API",
   "types": "./types/lib/index.d.ts",
   "main": "./dist/index.js",

--- a/types/lib/b2b/client.d.ts
+++ b/types/lib/b2b/client.d.ts
@@ -3,7 +3,9 @@ import { Sessions } from "./sessions";
 import { Organizations } from "./organizations";
 import { SSO } from "./sso";
 import { BaseClient, ClientConfig } from "../shared/client";
+import { JwtConfig } from "../shared/sessions";
 export declare class B2BClient extends BaseClient {
+    protected jwtConfig: JwtConfig;
     magicLinks: MagicLinks;
     sessions: Sessions;
     organizations: Organizations;

--- a/types/lib/b2c/client.d.ts
+++ b/types/lib/b2c/client.d.ts
@@ -8,7 +8,9 @@ import { TOTPs } from "./totps";
 import { Users } from "./users";
 import { WebAuthn } from "./webauthn";
 import { BaseClient, ClientConfig } from "../shared/client";
+import { JwtConfig } from "../shared/sessions";
 export declare class Client extends BaseClient {
+    protected jwtConfig: JwtConfig;
     users: Users;
     magicLinks: MagicLinks;
     otps: OTPs;

--- a/types/lib/shared/client.d.ts
+++ b/types/lib/shared/client.d.ts
@@ -1,7 +1,6 @@
 /// <reference types="node" />
 import * as http from "http";
 import { fetchConfig } from ".";
-import { JwtConfig } from "./sessions";
 export interface ClientConfig {
     project_id: string;
     secret: string;
@@ -12,6 +11,5 @@ export interface ClientConfig {
 export declare class BaseClient {
     protected fetchConfig: fetchConfig;
     protected baseURL: string;
-    protected jwtConfig: JwtConfig;
     constructor(config: ClientConfig);
 }


### PR DESCRIPTION
Creates separate JWKS client URLs for B2B and B2C clients - B2B clients need `/b2b/sessions/jwks`, while B2C clients need `/sessions/jwks`