### PR TITLE
AUTH-716: Add support for non-English locales in B2B email magic links

### DIFF
--- a/lib/b2b/magic_links.ts
+++ b/lib/b2b/magic_links.ts
@@ -10,6 +10,7 @@ export interface LoginOrSignupByEmailRequest {
   pkce_code_challenge?: string;
   login_template_id?: string;
   signup_template_id?: string;
+  locale?: "en" | "es" | "pt-br";
 }
 
 export interface LoginOrSignupByEmailResponse extends ResponseWithMember {
@@ -25,6 +26,7 @@ export interface InviteByEmailRequest {
   invite_template_id?: string;
   trusted_metadata?: Record<string, any>; // eslint-disable-line @typescript-eslint/no-explicit-any
   untrusted_metadata?: Record<string, any>; // eslint-disable-line @typescript-eslint/no-explicit-any
+  locale?: "en" | "es" | "pt-br";
 }
 
 export type InviteByEmailResponse = ResponseWithMember;
@@ -52,6 +54,7 @@ export interface DiscoveryByEmailRequest {
   discovery_redirect_url?: string;
   pkce_code_challenge?: string;
   login_template_id?: string;
+  locale?: "en" | "es" | "pt-br";
 }
 
 export type DiscoveryByEmailResponse = BaseResponse;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stytch",
-  "version": "6.1.2",
+  "version": "6.1.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "stytch",
-      "version": "6.1.2",
+      "version": "6.1.3",
       "license": "MIT",
       "dependencies": {
         "isomorphic-unfetch": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stytch",
-  "version": "6.1.2",
+  "version": "6.1.3",
   "description": "A wrapper for the Stytch API",
   "types": "./types/lib/index.d.ts",
   "main": "./dist/index.js",

--- a/test/b2b/magic_links.test.ts
+++ b/test/b2b/magic_links.test.ts
@@ -77,6 +77,7 @@ describe("magicLinks.email.loginOrSignup", () => {
         pkce_code_challenge: "000000000000",
         login_template_id: "login_dark_mode",
         signup_template_id: "signup_dark_mode",
+        locale: "es",
       })
     ).resolves.toMatchObject({
       method: "POST",
@@ -86,6 +87,10 @@ describe("magicLinks.email.loginOrSignup", () => {
         organization_id: "organization-id-1234",
         login_redirect_url: "http://localhost:8000/login",
         signup_redirect_url: "http://localhost:8000/signup",
+        pkce_code_challenge: "000000000000",
+        login_template_id: "login_dark_mode",
+        signup_template_id: "signup_dark_mode",
+        locale: "es",
       },
     });
   });
@@ -118,6 +123,7 @@ describe("magicLinks.email.invite", () => {
         invite_template_id: "invite_darkmode",
         trusted_metadata: { a: 1, b: [2] },
         untrusted_metadata: { a: 1, b: [2] },
+        locale: "pt-br",
       })
     ).resolves.toMatchObject({
       method: "POST",
@@ -131,6 +137,7 @@ describe("magicLinks.email.invite", () => {
         invite_template_id: "invite_darkmode",
         trusted_metadata: { a: 1, b: [2] },
         untrusted_metadata: { a: 1, b: [2] },
+        locale: "pt-br",
       },
     });
   });
@@ -157,6 +164,7 @@ describe("magicLinks.email.discovery.send", () => {
         discovery_redirect_url: "http://localhost:8000/discover",
         pkce_code_challenge: "000000000000",
         login_template_id: "login_dark_mode",
+        locale: "pt-br",
       })
     ).resolves.toMatchObject({
       method: "POST",
@@ -166,6 +174,7 @@ describe("magicLinks.email.discovery.send", () => {
         discovery_redirect_url: "http://localhost:8000/discover",
         pkce_code_challenge: "000000000000",
         login_template_id: "login_dark_mode",
+        locale: "pt-br",
       },
     });
   });

--- a/types/lib/b2b/magic_links.d.ts
+++ b/types/lib/b2b/magic_links.d.ts
@@ -9,6 +9,7 @@ export interface LoginOrSignupByEmailRequest {
     pkce_code_challenge?: string;
     login_template_id?: string;
     signup_template_id?: string;
+    locale?: "en" | "es" | "pt-br";
 }
 export interface LoginOrSignupByEmailResponse extends ResponseWithMember {
     member_created: boolean;
@@ -22,6 +23,7 @@ export interface InviteByEmailRequest {
     invite_template_id?: string;
     trusted_metadata?: Record<string, any>;
     untrusted_metadata?: Record<string, any>;
+    locale?: "en" | "es" | "pt-br";
 }
 export declare type InviteByEmailResponse = ResponseWithMember;
 export interface AuthenticateRequest {
@@ -45,6 +47,7 @@ export interface DiscoveryByEmailRequest {
     discovery_redirect_url?: string;
     pkce_code_challenge?: string;
     login_template_id?: string;
+    locale?: "en" | "es" | "pt-br";
 }
 export declare type DiscoveryByEmailResponse = BaseResponse;
 export interface DiscoveryAuthenticateRequest {


### PR DESCRIPTION
Adds the "locale" argument to the B2B EML endpoints.