### PR TITLE
Infer environment from project_id

### DIFF
--- a/dist/shared/client.js
+++ b/dist/shared/client.js
@@ -32,7 +32,11 @@ class BaseClient {
     }
 
     if (!config.env) {
-      throw new Error('Missing "env" in config');
+      if (config.project_id.startsWith("project-live-")) {
+        config.env = envs.live;
+      } else {
+        config.env = envs.test;
+      }
     }
 
     if (config.env != envs.test && config.env != envs.live) {// TODO: warn about non-production configuration

--- a/lib/shared/client.ts
+++ b/lib/shared/client.ts
@@ -9,7 +9,7 @@ const DEFAULT_TIMEOUT = 10 * 60 * 1000; // Ten minutes
 export interface ClientConfig {
   project_id: string;
   secret: string;
-  env: string;
+  env?: string;
   timeout?: number;
   agent?: http.Agent;
 }
@@ -34,7 +34,11 @@ export class BaseClient {
     }
 
     if (!config.env) {
-      throw new Error('Missing "env" in config');
+      if (config.project_id.startsWith("project-live-")) {
+        config.env = envs.live
+      } else {
+        config.env = envs.test
+      }
     }
 
     if (config.env != envs.test && config.env != envs.live) {

--- a/lib/shared/client.ts
+++ b/lib/shared/client.ts
@@ -35,9 +35,9 @@ export class BaseClient {
 
     if (!config.env) {
       if (config.project_id.startsWith("project-live-")) {
-        config.env = envs.live
+        config.env = envs.live;
       } else {
-        config.env = envs.test
+        config.env = envs.test;
       }
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stytch",
-  "version": "7.0.1",
+  "version": "7.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "stytch",
-      "version": "7.0.1",
+      "version": "7.1.0",
       "license": "MIT",
       "dependencies": {
         "isomorphic-unfetch": "^3.1.0",
@@ -10161,7 +10161,7 @@
       "resolved": "https://registry.npmjs.org/isomorphic-unfetch/-/isomorphic-unfetch-3.1.0.tgz",
       "integrity": "sha512-geDJjpoZ8N0kWexiwkX8F9NkTsXhetLPVbZFQ+JTW239QNOwvB0gniuR1Wc6f0AMTn7/mFGyXvHTifrCp/GH8Q==",
       "requires": {
-        "node-fetch": "^2.6.1",
+        "node-fetch": "2.6.9",
         "unfetch": "^4.2.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stytch",
-  "version": "7.0.1",
+  "version": "7.1.0",
   "description": "A wrapper for the Stytch API",
   "types": "./types/lib/index.d.ts",
   "main": "./dist/index.js",

--- a/test/shared/client.test.ts
+++ b/test/shared/client.test.ts
@@ -27,14 +27,4 @@ describe("config errors", () => {
       });
     }).toThrow(/Missing "secret" in config/);
   });
-
-  test("missing environment", () => {
-    expect(() => {
-      new BaseClient({
-        project_id: "project-test-00000000-0000-4000-8000-000000000000",
-        secret: "secret-test-11111111-1111-4111-8111-111111111111",
-        env: "",
-      });
-    }).toThrow(/Missing "env" in config/);
-  });
 });

--- a/types/lib/shared/client.d.ts
+++ b/types/lib/shared/client.d.ts
@@ -4,7 +4,7 @@ import { fetchConfig } from ".";
 export interface ClientConfig {
     project_id: string;
     secret: string;
-    env: string;
+    env?: string;
     timeout?: number;
     agent?: http.Agent;
 }


### PR DESCRIPTION
It's rare that someone would manually specify the environment unless they were working on something internally and wanted to hit internal development URLs. For every customer, they'd want the environment inferred from the given project ID (a test project can't be used in the live environment and vice versa).

This PR makes env an optional parameter and then sets it later depending on whether the project_id starts with `project-live-`.