### PR TITLE
Add registry-url during setup to allow for auto-publish

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -14,6 +14,7 @@ jobs:
       # Setup .npmrc file to publish to npm
       - uses: actions/setup-node@v3
         with:
+          registry-url: "https://registry.npmjs.org"
           node-version: "16"
 
       - name: Install


### PR DESCRIPTION
Was not aware that registry-url is needed so the auth token would work properly.

https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages
<img width="730" alt="image" src="https://github.com/stytchauth/stytch-node/assets/119902778/fdfa914c-0188-436c-af9d-aff36df0b929">
