### PR TITLE
Fix return type for deletePassword

### DIFF
--- a/lib/b2c/users.ts
+++ b/lib/b2c/users.ts
@@ -362,9 +362,7 @@ export class Users {
     });
   }
 
-  deletePassword(
-    passwordID: string
-  ): Promise<B2CUsersDeletePasswordResponse> {
+  deletePassword(passwordID: string): Promise<B2CUsersDeletePasswordResponse> {
     return request(this.fetchConfig, {
       method: "DELETE",
       url: this.endpoint(`passwords/${passwordID}`),

--- a/lib/b2c/users.ts
+++ b/lib/b2c/users.ts
@@ -364,7 +364,7 @@ export class Users {
 
   deletePassword(
     passwordID: string
-  ): Promise<B2CUsersDeleteCryptoWalletResponse> {
+  ): Promise<B2CUsersDeletePasswordResponse> {
     return request(this.fetchConfig, {
       method: "DELETE",
       url: this.endpoint(`passwords/${passwordID}`),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stytch",
-  "version": "7.1.2",
+  "version": "7.1.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "stytch",
-      "version": "7.1.2",
+      "version": "7.1.3",
       "license": "MIT",
       "dependencies": {
         "isomorphic-unfetch": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stytch",
-  "version": "7.1.2",
+  "version": "7.1.3",
   "description": "A wrapper for the Stytch API",
   "types": "./types/lib/index.d.ts",
   "main": "./dist/index.js",

--- a/types/lib/b2c/users.d.ts
+++ b/types/lib/b2c/users.d.ts
@@ -185,6 +185,6 @@ export declare class Users {
     deleteBiometricRegistration(biometricRegistrationID: string): Promise<B2CUsersDeleteBiometricRegistrationResponse>;
     deleteTOTP(totpID: string): Promise<B2CUsersDeleteTOTPResponse>;
     deleteCryptoWallet(cryptoWalletID: string): Promise<B2CUsersDeleteCryptoWalletResponse>;
-    deletePassword(passwordID: string): Promise<B2CUsersDeleteCryptoWalletResponse>;
+    deletePassword(passwordID: string): Promise<B2CUsersDeletePasswordResponse>;
     deleteOAuthUserRegistration(oauthUserRegistrationID: string): Promise<B2CUsersDeleteOAuthUserRegistrationResponse>;
 }


### PR DESCRIPTION
The return type for the `deletePassword` method is `Promise<B2CUsersDeleteCryptoWalletResponse>`, but it looks like it should probably be `Promise<B2CUsersDeletePasswordResponse>`.