### PR TITLE
fix: Publish non-rc version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stytch",
-  "version": "9.0.0-rc.1",
+  "version": "9.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "stytch",
-      "version": "9.0.0-rc.1",
+      "version": "9.0.0",
       "license": "MIT",
       "dependencies": {
         "jose": "^4.14.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stytch",
-  "version": "9.0.0-rc.1",
+  "version": "9.0.0",
   "description": "A wrapper for the Stytch API",
   "types": "./types/lib/index.d.ts",
   "main": "./dist/index.js",


### PR DESCRIPTION
#255 accidentally left in the `9.0.0-rc.1` version. We're ready to release, so let's publish `9.0.0`