### PR TITLE
fix: [AUTH-2047] disable fetch cache for all requests

### DIFF
--- a/dist/shared/index.js
+++ b/dist/shared/index.js
@@ -16,6 +16,7 @@ async function request(fetchConfig, requestConfig) {
     response = await fetch(url.toString(), {
       method: requestConfig.method,
       body: body,
+      cache: "no-store",
       ...fetchConfig
     });
   } catch (e) {

--- a/lib/shared/index.ts
+++ b/lib/shared/index.ts
@@ -18,12 +18,12 @@ export type requestConfig = {
 
 export async function request<T>(
   fetchConfig: fetchConfig,
-  requestConfig: requestConfig
+  requestConfig: requestConfig,
 ): Promise<T> {
   const url = new URL(requestConfig.url, fetchConfig.baseURL);
   if (requestConfig.params) {
     Object.entries(requestConfig.params).forEach(([key, value]) =>
-      url.searchParams.append(key, String(value))
+      url.searchParams.append(key, String(value)),
     );
   }
 
@@ -36,6 +36,7 @@ export async function request<T>(
     response = await fetch(url.toString(), {
       method: requestConfig.method,
       body: body,
+      cache: "no-store",
       ...fetchConfig,
     });
   } catch (e) {
@@ -50,7 +51,7 @@ export async function request<T>(
     const err = e as Error;
     throw new RequestError(
       `Unable to parse JSON response from server: ${err.message}`,
-      requestConfig
+      requestConfig,
     );
   }
 

--- a/lib/shared/index.ts
+++ b/lib/shared/index.ts
@@ -18,12 +18,12 @@ export type requestConfig = {
 
 export async function request<T>(
   fetchConfig: fetchConfig,
-  requestConfig: requestConfig,
+  requestConfig: requestConfig
 ): Promise<T> {
   const url = new URL(requestConfig.url, fetchConfig.baseURL);
   if (requestConfig.params) {
     Object.entries(requestConfig.params).forEach(([key, value]) =>
-      url.searchParams.append(key, String(value)),
+      url.searchParams.append(key, String(value))
     );
   }
 
@@ -51,7 +51,7 @@ export async function request<T>(
     const err = e as Error;
     throw new RequestError(
       `Unable to parse JSON response from server: ${err.message}`,
-      requestConfig,
+      requestConfig
     );
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "stytch",
-  "version": "9.0.4",
+  "version": "9.0.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stytch",
-  "version": "9.0.4",
+  "version": "9.0.5",
   "description": "A wrapper for the Stytch API",
   "types": "./types/lib/index.d.ts",
   "main": "./dist/index.js",

--- a/test/shared/shared.test.ts
+++ b/test/shared/shared.test.ts
@@ -23,11 +23,12 @@ describe("request", () => {
       request(MOCK_FETCH_CONFIG, {
         url: "http://localhost:8000/hello",
         method: "GET",
-      })
+      }),
     ).resolves.toEqual({ key: "value" });
 
     expect(fetchMock).toHaveBeenCalledWith("http://localhost:8000/hello", {
       method: "GET",
+      cache: "no-store",
       ...MOCK_FETCH_CONFIG,
     });
   });
@@ -37,6 +38,7 @@ describe("request", () => {
     await request(MOCK_FETCH_CONFIG, {
       url: "http://localhost:8000/hello",
       method: "GET",
+      cache: "no-store",
       params: {
         string: "here",
         number: 1234,
@@ -47,6 +49,7 @@ describe("request", () => {
 
     expect(fetchMock).toHaveBeenCalledWith(expectedURL, {
       method: "GET",
+      cache: "no-store",
       ...MOCK_FETCH_CONFIG,
     });
   });
@@ -67,6 +70,7 @@ describe("request", () => {
 
     expect(fetchMock).toHaveBeenCalledWith("http://localhost:8000/hello", {
       method: "GET",
+      cache: "no-store",
       body: `{"string":"here","number":1234,"deep":{"array":[123]}}`,
       ...MOCK_FETCH_CONFIG,
     });
@@ -82,7 +86,7 @@ describe("request", () => {
         error_message: "Whoops!",
         error_url: "https://stytch.com/docs/api/errors/400",
       },
-      400
+      400,
     );
 
     await request(MOCK_FETCH_CONFIG, {
@@ -102,7 +106,7 @@ describe("request", () => {
       expect.objectContaining({
         method: "POST",
         ...MOCK_FETCH_CONFIG,
-      })
+      }),
     );
   });
 
@@ -114,13 +118,13 @@ describe("request", () => {
     return request(MOCK_FETCH_CONFIG, { url: "nowhere", method: "GET" }).catch(
       (err) => {
         expect(err.toString()).toEqual(
-          "Error: connect ECONNREFUSED 127.0.0.1:80"
+          "Error: connect ECONNREFUSED 127.0.0.1:80",
         );
         expect(err.message).toEqual("connect ECONNREFUSED 127.0.0.1:80");
         expect(err.request).toMatchObject({
           url: "nowhere",
         });
-      }
+      },
     );
   });
 
@@ -132,13 +136,13 @@ describe("request", () => {
     return request(MOCK_FETCH_CONFIG, { url: "nowhere", method: "GET" }).catch(
       (err) => {
         expect(err.toString()).toEqual(
-          "Error: connect ECONNREFUSED 127.0.0.1:80"
+          "Error: connect ECONNREFUSED 127.0.0.1:80",
         );
         expect(err.message).toEqual("connect ECONNREFUSED 127.0.0.1:80");
         expect(err.request).toMatchObject({
           url: "nowhere",
         });
-      }
+      },
     );
   });
 
@@ -154,7 +158,7 @@ describe("request", () => {
       data: { bigint: BigInt(10) },
     }).catch((err) => {
       expect(err.toString()).toEqual(
-        "Error: Do not know how to serialize a BigInt"
+        "Error: Do not know how to serialize a BigInt",
       );
       expect(err.message).toEqual("Do not know how to serialize a BigInt");
       expect(err.request).toMatchObject({

--- a/test/shared/shared.test.ts
+++ b/test/shared/shared.test.ts
@@ -23,7 +23,7 @@ describe("request", () => {
       request(MOCK_FETCH_CONFIG, {
         url: "http://localhost:8000/hello",
         method: "GET",
-      }),
+      })
     ).resolves.toEqual({ key: "value" });
 
     expect(fetchMock).toHaveBeenCalledWith("http://localhost:8000/hello", {
@@ -86,7 +86,7 @@ describe("request", () => {
         error_message: "Whoops!",
         error_url: "https://stytch.com/docs/api/errors/400",
       },
-      400,
+      400
     );
 
     await request(MOCK_FETCH_CONFIG, {
@@ -106,7 +106,7 @@ describe("request", () => {
       expect.objectContaining({
         method: "POST",
         ...MOCK_FETCH_CONFIG,
-      }),
+      })
     );
   });
 
@@ -118,13 +118,13 @@ describe("request", () => {
     return request(MOCK_FETCH_CONFIG, { url: "nowhere", method: "GET" }).catch(
       (err) => {
         expect(err.toString()).toEqual(
-          "Error: connect ECONNREFUSED 127.0.0.1:80",
+          "Error: connect ECONNREFUSED 127.0.0.1:80"
         );
         expect(err.message).toEqual("connect ECONNREFUSED 127.0.0.1:80");
         expect(err.request).toMatchObject({
           url: "nowhere",
         });
-      },
+      }
     );
   });
 
@@ -136,13 +136,13 @@ describe("request", () => {
     return request(MOCK_FETCH_CONFIG, { url: "nowhere", method: "GET" }).catch(
       (err) => {
         expect(err.toString()).toEqual(
-          "Error: connect ECONNREFUSED 127.0.0.1:80",
+          "Error: connect ECONNREFUSED 127.0.0.1:80"
         );
         expect(err.message).toEqual("connect ECONNREFUSED 127.0.0.1:80");
         expect(err.request).toMatchObject({
           url: "nowhere",
         });
-      },
+      }
     );
   });
 
@@ -158,7 +158,7 @@ describe("request", () => {
       data: { bigint: BigInt(10) },
     }).catch((err) => {
       expect(err.toString()).toEqual(
-        "Error: Do not know how to serialize a BigInt",
+        "Error: Do not know how to serialize a BigInt"
       );
       expect(err.message).toEqual("Do not know how to serialize a BigInt");
       expect(err.request).toMatchObject({


### PR DESCRIPTION
This PR passes `cache: "no-store"` into all requests made by the SDK in order to disable the NextJS v13+ [Fetch Cache](https://nextjs.org/docs/app/api-reference/functions/fetch). We almost never want to cache responses from this client.

Customers that _do_ want to opt in to fetch cache behavior can use the workaround described in https://github.com/stytchauth/stytch-node/issues/262#issuecomment-1764910451 to set a custom cache setting on the private `fetchConfig`, which will override the value set in this PR.

I'll open up another feature request issue for tracking adding support for custom `fetch` options - either per client or per request.

Closes #262 