### PR TITLE
Update docs and support set_email_verified

### DIFF
--- a/dist/b2b/rbac.js
+++ b/dist/b2b/rbac.js
@@ -23,13 +23,13 @@ class RBAC {
    * Get the active RBAC Policy for your current Stytch Project. An RBAC Policy is the canonical document
    * that stores all defined Resources and Roles within your RBAC permissioning model.
    *
-   * When using the backend SDKs, the RBAC Policy will automatically be loaded and refreshed in the
-   * background to allow for local evaluations, eliminating the need for an extra request to Stytch.
+   * When using the backend SDKs, the RBAC Policy will be cached to allow for local evaluations, eliminating
+   * the need for an extra request to Stytch. The policy will be refreshed if an authorization check is
+   * requested and the RBAC policy was last updated more than 5 minutes ago.
    *
-   * Resources and Roles can be created and managed within the [Dashboard](/dashboard). Additionally,
+   * Resources and Roles can be created and managed within the [Dashboard](/dashboard/rbac). Additionally,
    * [Role assignment](https://stytch.com/docs/b2b/guides/rbac/role-assignment) can be programmatically
    * managed through certain Stytch API endpoints.
-   *
    *
    * Check out the [RBAC overview](https://stytch.com/docs/b2b/guides/rbac/overview) to learn more about
    * Stytch's RBAC permissioning model.

--- a/lib/b2b/discovery_organizations.ts
+++ b/lib/b2b/discovery_organizations.ts
@@ -165,18 +165,18 @@ export interface B2BDiscoveryOrganizationsCreateRequest {
    */
   rbac_email_implicit_role_assignments?: EmailImplicitRoleAssignment[];
   /**
-   * The setting that controls which mfa methods can be used by Members of an Organization. The accepted
+   * The setting that controls which MFA methods can be used by Members of an Organization. The accepted
    * values are:
    *
    *   `ALL_ALLOWED` – the default setting which allows all authentication methods to be used.
    *
-   *   `RESTRICTED` – only methods that comply with `allowed_auth_methods` can be used for authentication.
+   *   `RESTRICTED` – only methods that comply with `allowed_mfa_methods` can be used for authentication.
    * This setting does not apply to Members with `is_breakglass` set to `true`.
    *
    */
   mfa_methods?: string;
   /**
-   * An array of allowed mfa authentication methods. This list is enforced when `mfa_methods` is set to
+   * An array of allowed MFA authentication methods. This list is enforced when `mfa_methods` is set to
    * `RESTRICTED`.
    *   The list's accepted values are: `sms_otp` and `totp`.
    *

--- a/lib/b2b/organizations.ts
+++ b/lib/b2b/organizations.ts
@@ -354,18 +354,18 @@ export interface Organization {
    */
   rbac_email_implicit_role_assignments: EmailImplicitRoleAssignment[];
   /**
-   * The setting that controls which mfa methods can be used by Members of an Organization. The accepted
+   * The setting that controls which MFA methods can be used by Members of an Organization. The accepted
    * values are:
    *
    *   `ALL_ALLOWED` – the default setting which allows all authentication methods to be used.
    *
-   *   `RESTRICTED` – only methods that comply with `allowed_auth_methods` can be used for authentication.
+   *   `RESTRICTED` – only methods that comply with `allowed_mfa_methods` can be used for authentication.
    * This setting does not apply to Members with `is_breakglass` set to `true`.
    *
    */
   mfa_methods: string;
   /**
-   * An array of allowed mfa authentication methods. This list is enforced when `mfa_methods` is set to
+   * An array of allowed MFA authentication methods. This list is enforced when `mfa_methods` is set to
    * `RESTRICTED`.
    *   The list's accepted values are: `sms_otp` and `totp`.
    *
@@ -501,18 +501,18 @@ export interface B2BOrganizationsCreateRequest {
    */
   rbac_email_implicit_role_assignments?: EmailImplicitRoleAssignment[];
   /**
-   * The setting that controls which mfa methods can be used by Members of an Organization. The accepted
+   * The setting that controls which MFA methods can be used by Members of an Organization. The accepted
    * values are:
    *
    *   `ALL_ALLOWED` – the default setting which allows all authentication methods to be used.
    *
-   *   `RESTRICTED` – only methods that comply with `allowed_auth_methods` can be used for authentication.
+   *   `RESTRICTED` – only methods that comply with `allowed_mfa_methods` can be used for authentication.
    * This setting does not apply to Members with `is_breakglass` set to `true`.
    *
    */
   mfa_methods?: string;
   /**
-   * An array of allowed mfa authentication methods. This list is enforced when `mfa_methods` is set to
+   * An array of allowed MFA authentication methods. This list is enforced when `mfa_methods` is set to
    * `RESTRICTED`.
    *   The list's accepted values are: `sms_otp` and `totp`.
    *
@@ -804,22 +804,22 @@ export interface B2BOrganizationsUpdateRequest {
    */
   rbac_email_implicit_role_assignments?: string[];
   /**
-   * The setting that controls which mfa methods can be used by Members of an Organization. The accepted
+   * The setting that controls which MFA methods can be used by Members of an Organization. The accepted
    * values are:
    *
    *   `ALL_ALLOWED` – the default setting which allows all authentication methods to be used.
    *
-   *   `RESTRICTED` – only methods that comply with `allowed_auth_methods` can be used for authentication.
+   *   `RESTRICTED` – only methods that comply with `allowed_mfa_methods` can be used for authentication.
    * This setting does not apply to Members with `is_breakglass` set to `true`.
    *
    *
    * If this field is provided and a session header is passed into the request, the Member Session must have
-   * permission to perform the `update.settings.allowed-auth-methods` action on the `stytch.organization`
+   * permission to perform the `update.settings.allowed-mfa-methods` action on the `stytch.organization`
    * Resource.
    */
   mfa_methods?: string;
   /**
-   * An array of allowed mfa authentication methods. This list is enforced when `mfa_methods` is set to
+   * An array of allowed MFA authentication methods. This list is enforced when `mfa_methods` is set to
    * `RESTRICTED`.
    *   The list's accepted values are: `sms_otp` and `totp`.
    *

--- a/lib/b2b/organizations_members.ts
+++ b/lib/b2b/organizations_members.ts
@@ -450,7 +450,7 @@ export interface B2BOrganizationsMembersUpdateRequest {
    * more details.
    *
    * If this field is provided and a session header is passed into the request, the Member Session must have
-   * permission to perform the `update.info.is-breakglass` action on the `stytch.member` Resource.
+   * permission to perform the `update.settings.is-breakglass` action on the `stytch.member` Resource.
    */
   is_breakglass?: boolean;
   /**

--- a/lib/b2b/rbac.ts
+++ b/lib/b2b/rbac.ts
@@ -16,19 +16,120 @@ export interface Policy {
 }
 
 export interface PolicyResource {
+  /**
+   * A unique identifier of the RBAC Resource, provided by the developer and intended to be human-readable.
+   *
+   *   A `resource_id` is not allowed to start with `stytch`, which is a special prefix used for Stytch
+   * default Resources with reserved  `resource_id`s. These include:
+   *
+   *   * `stytch.organization`
+   *   * `stytch.member`
+   *   * `stytch.sso`
+   *   * `stytch.self`
+   *
+   *   Check out the
+   * [guide on Stytch default Resources](https://stytch.com/docs/b2b/guides/rbac/stytch-defaults) for a more
+   * detailed explanation.
+   *
+   *
+   */
   resource_id: string;
+  // The description of the RBAC Resource.
   description: string;
+  /**
+   * A list of all possible actions for a provided Resource.
+   *
+   *   Reserved `actions` that are predefined by Stytch include:
+   *
+   *   * `*`
+   *   * For the `stytch.organization` Resource:
+   *     * `update.info.name`
+   *     * `update.info.slug`
+   *     * `update.info.untrusted_metadata`
+   *     * `update.info.email_jit_provisioning`
+   *     * `update.info.logo_url`
+   *     * `update.info.email_invites`
+   *     * `update.info.allowed_domains`
+   *     * `update.info.default_sso_connection`
+   *     * `update.info.sso_jit_provisioning`
+   *     * `update.info.mfa_policy`
+   *     * `update.info.implicit_roles`
+   *     * `delete`
+   *   * For the `stytch.member` Resource:
+   *     * `create`
+   *     * `update.info.name`
+   *     * `update.info.untrusted_metadata`
+   *     * `update.info.mfa-phone`
+   *     * `update.info.delete.mfa-phone`
+   *     * `update.settings.is-breakglass`
+   *     * `update.settings.mfa_enrolled`
+   *     * `update.settings.roles`
+   *     * `search`
+   *     * `delete`
+   *   * For the `stytch.sso` Resource:
+   *     * `create`
+   *     * `update`
+   *     * `delete`
+   *   * For the `stytch.self` Resource:
+   *     * `update.info.name`
+   *     * `update.info.untrusted_metadata`
+   *     * `update.info.mfa-phone`
+   *     * `update.info.delete.mfa-phone`
+   *     * `update.info.delete.password`
+   *     * `update.settings.mfa_enrolled`
+   *     * `delete`
+   *
+   */
   actions: string[];
 }
 
 export interface PolicyRole {
+  /**
+   * The unique identifier of the RBAC Role, provided by the developer and intended to be human-readable.
+   *
+   *   Reserved `role_id`s that are predefined by Stytch include:
+   *
+   *   * `stytch_member`
+   *   * `stytch_admin`
+   *
+   *   Check out the [guide on Stytch default Roles](https://stytch.com/docs/b2b/guides/rbac/stytch-defaults)
+   * for a more detailed explanation.
+   *
+   *
+   */
   role_id: string;
+  // The description of the RBAC Role.
   description: string;
+  /**
+   * A list of permissions that link a [Resource](https://stytch.com/docs/b2b/api/rbac-resource-object) to a
+   * list of actions.
+   */
   permissions: PolicyRolePermission[];
 }
 
 export interface PolicyRolePermission {
+  /**
+   * A unique identifier of the RBAC Resource, provided by the developer and intended to be human-readable.
+   *
+   *   A `resource_id` is not allowed to start with `stytch`, which is a special prefix used for Stytch
+   * default Resources with reserved  `resource_id`s. These include:
+   *
+   *   * `stytch.organization`
+   *   * `stytch.member`
+   *   * `stytch.sso`
+   *   * `stytch.self`
+   *
+   *   Check out the
+   * [guide on Stytch default Resources](https://stytch.com/docs/b2b/guides/rbac/stytch-defaults) for a more
+   * detailed explanation.
+   *
+   *
+   */
   resource_id: string;
+  /**
+   * A list of permitted actions the Role is authorized to take with the provided Resource. You can use `*`
+   * as a wildcard to grant a Role permission to use all possible actions related to the Resource.
+   */
   actions: string[];
 }
 
@@ -46,7 +147,7 @@ export interface B2BRBACPolicyResponse {
   status_code: number;
   /**
    * The RBAC Policy document that contains all defined Roles and Resources – which are managed in the
-   * [Dashboard](/dashboard). Read more about these entities and how they work in our
+   * [Dashboard](/dashboard/rbac). Read more about these entities and how they work in our
    * [RBAC overview](https://stytch.com/docs/b2b/guides/rbac/overview).
    */
   policy?: Policy;
@@ -63,13 +164,13 @@ export class RBAC {
    * Get the active RBAC Policy for your current Stytch Project. An RBAC Policy is the canonical document
    * that stores all defined Resources and Roles within your RBAC permissioning model.
    *
-   * When using the backend SDKs, the RBAC Policy will automatically be loaded and refreshed in the
-   * background to allow for local evaluations, eliminating the need for an extra request to Stytch.
+   * When using the backend SDKs, the RBAC Policy will be cached to allow for local evaluations, eliminating
+   * the need for an extra request to Stytch. The policy will be refreshed if an authorization check is
+   * requested and the RBAC policy was last updated more than 5 minutes ago.
    *
-   * Resources and Roles can be created and managed within the [Dashboard](/dashboard). Additionally,
+   * Resources and Roles can be created and managed within the [Dashboard](/dashboard/rbac). Additionally,
    * [Role assignment](https://stytch.com/docs/b2b/guides/rbac/role-assignment) can be programmatically
    * managed through certain Stytch API endpoints.
-   *
    *
    * Check out the [RBAC overview](https://stytch.com/docs/b2b/guides/rbac/overview) to learn more about
    * Stytch's RBAC permissioning model.

--- a/lib/b2c/passwords.ts
+++ b/lib/b2c/passwords.ts
@@ -307,6 +307,15 @@ export interface PasswordsMigrateRequest {
    * behavior details.
    */
   untrusted_metadata?: Record<string, any>; // eslint-disable-line @typescript-eslint/no-explicit-any
+  /**
+   * Whether to set the user's email as verified. This is a dangerous field. Incorrect use may lead to users
+   * getting erroneously
+   *                 deduplicated into one user object. This flag should only be set if you can attest that
+   * the user owns the email address in question.
+   *                 Access to this field is restricted. To enable it, please send us a note at
+   * support@stytch.com.
+   */
+  set_email_verified?: boolean;
   // The name of the user. Each field in the name object is optional.
   name?: Name;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stytch",
-  "version": "10.4.0",
+  "version": "10.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "stytch",
-      "version": "10.4.0",
+      "version": "10.5.0",
       "license": "MIT",
       "dependencies": {
         "jose": "^4.14.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stytch",
-  "version": "10.4.0",
+  "version": "10.5.0",
   "description": "A wrapper for the Stytch API",
   "types": "./types/lib/index.d.ts",
   "main": "./dist/index.js",

--- a/types/lib/b2b/discovery_organizations.d.ts
+++ b/types/lib/b2b/discovery_organizations.d.ts
@@ -149,18 +149,18 @@ export interface B2BDiscoveryOrganizationsCreateRequest {
      */
     rbac_email_implicit_role_assignments?: EmailImplicitRoleAssignment[];
     /**
-     * The setting that controls which mfa methods can be used by Members of an Organization. The accepted
+     * The setting that controls which MFA methods can be used by Members of an Organization. The accepted
      * values are:
      *
      *   `ALL_ALLOWED` – the default setting which allows all authentication methods to be used.
      *
-     *   `RESTRICTED` – only methods that comply with `allowed_auth_methods` can be used for authentication.
+     *   `RESTRICTED` – only methods that comply with `allowed_mfa_methods` can be used for authentication.
      * This setting does not apply to Members with `is_breakglass` set to `true`.
      *
      */
     mfa_methods?: string;
     /**
-     * An array of allowed mfa authentication methods. This list is enforced when `mfa_methods` is set to
+     * An array of allowed MFA authentication methods. This list is enforced when `mfa_methods` is set to
      * `RESTRICTED`.
      *   The list's accepted values are: `sms_otp` and `totp`.
      *

--- a/types/lib/b2b/organizations.d.ts
+++ b/types/lib/b2b/organizations.d.ts
@@ -317,18 +317,18 @@ export interface Organization {
      */
     rbac_email_implicit_role_assignments: EmailImplicitRoleAssignment[];
     /**
-     * The setting that controls which mfa methods can be used by Members of an Organization. The accepted
+     * The setting that controls which MFA methods can be used by Members of an Organization. The accepted
      * values are:
      *
      *   `ALL_ALLOWED` – the default setting which allows all authentication methods to be used.
      *
-     *   `RESTRICTED` – only methods that comply with `allowed_auth_methods` can be used for authentication.
+     *   `RESTRICTED` – only methods that comply with `allowed_mfa_methods` can be used for authentication.
      * This setting does not apply to Members with `is_breakglass` set to `true`.
      *
      */
     mfa_methods: string;
     /**
-     * An array of allowed mfa authentication methods. This list is enforced when `mfa_methods` is set to
+     * An array of allowed MFA authentication methods. This list is enforced when `mfa_methods` is set to
      * `RESTRICTED`.
      *   The list's accepted values are: `sms_otp` and `totp`.
      *
@@ -450,18 +450,18 @@ export interface B2BOrganizationsCreateRequest {
      */
     rbac_email_implicit_role_assignments?: EmailImplicitRoleAssignment[];
     /**
-     * The setting that controls which mfa methods can be used by Members of an Organization. The accepted
+     * The setting that controls which MFA methods can be used by Members of an Organization. The accepted
      * values are:
      *
      *   `ALL_ALLOWED` – the default setting which allows all authentication methods to be used.
      *
-     *   `RESTRICTED` – only methods that comply with `allowed_auth_methods` can be used for authentication.
+     *   `RESTRICTED` – only methods that comply with `allowed_mfa_methods` can be used for authentication.
      * This setting does not apply to Members with `is_breakglass` set to `true`.
      *
      */
     mfa_methods?: string;
     /**
-     * An array of allowed mfa authentication methods. This list is enforced when `mfa_methods` is set to
+     * An array of allowed MFA authentication methods. This list is enforced when `mfa_methods` is set to
      * `RESTRICTED`.
      *   The list's accepted values are: `sms_otp` and `totp`.
      *
@@ -734,22 +734,22 @@ export interface B2BOrganizationsUpdateRequest {
      */
     rbac_email_implicit_role_assignments?: string[];
     /**
-     * The setting that controls which mfa methods can be used by Members of an Organization. The accepted
+     * The setting that controls which MFA methods can be used by Members of an Organization. The accepted
      * values are:
      *
      *   `ALL_ALLOWED` – the default setting which allows all authentication methods to be used.
      *
-     *   `RESTRICTED` – only methods that comply with `allowed_auth_methods` can be used for authentication.
+     *   `RESTRICTED` – only methods that comply with `allowed_mfa_methods` can be used for authentication.
      * This setting does not apply to Members with `is_breakglass` set to `true`.
      *
      *
      * If this field is provided and a session header is passed into the request, the Member Session must have
-     * permission to perform the `update.settings.allowed-auth-methods` action on the `stytch.organization`
+     * permission to perform the `update.settings.allowed-mfa-methods` action on the `stytch.organization`
      * Resource.
      */
     mfa_methods?: string;
     /**
-     * An array of allowed mfa authentication methods. This list is enforced when `mfa_methods` is set to
+     * An array of allowed MFA authentication methods. This list is enforced when `mfa_methods` is set to
      * `RESTRICTED`.
      *   The list's accepted values are: `sms_otp` and `totp`.
      *

--- a/types/lib/b2b/organizations_members.d.ts
+++ b/types/lib/b2b/organizations_members.d.ts
@@ -369,7 +369,7 @@ export interface B2BOrganizationsMembersUpdateRequest {
      * more details.
      *
      * If this field is provided and a session header is passed into the request, the Member Session must have
-     * permission to perform the `update.info.is-breakglass` action on the `stytch.member` Resource.
+     * permission to perform the `update.settings.is-breakglass` action on the `stytch.member` Resource.
      */
     is_breakglass?: boolean;
     /**

--- a/types/lib/b2b/rbac.d.ts
+++ b/types/lib/b2b/rbac.d.ts
@@ -4,17 +4,116 @@ export interface Policy {
     resources: PolicyResource[];
 }
 export interface PolicyResource {
+    /**
+     * A unique identifier of the RBAC Resource, provided by the developer and intended to be human-readable.
+     *
+     *   A `resource_id` is not allowed to start with `stytch`, which is a special prefix used for Stytch
+     * default Resources with reserved  `resource_id`s. These include:
+     *
+     *   * `stytch.organization`
+     *   * `stytch.member`
+     *   * `stytch.sso`
+     *   * `stytch.self`
+     *
+     *   Check out the
+     * [guide on Stytch default Resources](https://stytch.com/docs/b2b/guides/rbac/stytch-defaults) for a more
+     * detailed explanation.
+     *
+     *
+     */
     resource_id: string;
     description: string;
+    /**
+     * A list of all possible actions for a provided Resource.
+     *
+     *   Reserved `actions` that are predefined by Stytch include:
+     *
+     *   * `*`
+     *   * For the `stytch.organization` Resource:
+     *     * `update.info.name`
+     *     * `update.info.slug`
+     *     * `update.info.untrusted_metadata`
+     *     * `update.info.email_jit_provisioning`
+     *     * `update.info.logo_url`
+     *     * `update.info.email_invites`
+     *     * `update.info.allowed_domains`
+     *     * `update.info.default_sso_connection`
+     *     * `update.info.sso_jit_provisioning`
+     *     * `update.info.mfa_policy`
+     *     * `update.info.implicit_roles`
+     *     * `delete`
+     *   * For the `stytch.member` Resource:
+     *     * `create`
+     *     * `update.info.name`
+     *     * `update.info.untrusted_metadata`
+     *     * `update.info.mfa-phone`
+     *     * `update.info.delete.mfa-phone`
+     *     * `update.settings.is-breakglass`
+     *     * `update.settings.mfa_enrolled`
+     *     * `update.settings.roles`
+     *     * `search`
+     *     * `delete`
+     *   * For the `stytch.sso` Resource:
+     *     * `create`
+     *     * `update`
+     *     * `delete`
+     *   * For the `stytch.self` Resource:
+     *     * `update.info.name`
+     *     * `update.info.untrusted_metadata`
+     *     * `update.info.mfa-phone`
+     *     * `update.info.delete.mfa-phone`
+     *     * `update.info.delete.password`
+     *     * `update.settings.mfa_enrolled`
+     *     * `delete`
+     *
+     */
     actions: string[];
 }
 export interface PolicyRole {
+    /**
+     * The unique identifier of the RBAC Role, provided by the developer and intended to be human-readable.
+     *
+     *   Reserved `role_id`s that are predefined by Stytch include:
+     *
+     *   * `stytch_member`
+     *   * `stytch_admin`
+     *
+     *   Check out the [guide on Stytch default Roles](https://stytch.com/docs/b2b/guides/rbac/stytch-defaults)
+     * for a more detailed explanation.
+     *
+     *
+     */
     role_id: string;
     description: string;
+    /**
+     * A list of permissions that link a [Resource](https://stytch.com/docs/b2b/api/rbac-resource-object) to a
+     * list of actions.
+     */
     permissions: PolicyRolePermission[];
 }
 export interface PolicyRolePermission {
+    /**
+     * A unique identifier of the RBAC Resource, provided by the developer and intended to be human-readable.
+     *
+     *   A `resource_id` is not allowed to start with `stytch`, which is a special prefix used for Stytch
+     * default Resources with reserved  `resource_id`s. These include:
+     *
+     *   * `stytch.organization`
+     *   * `stytch.member`
+     *   * `stytch.sso`
+     *   * `stytch.self`
+     *
+     *   Check out the
+     * [guide on Stytch default Resources](https://stytch.com/docs/b2b/guides/rbac/stytch-defaults) for a more
+     * detailed explanation.
+     *
+     *
+     */
     resource_id: string;
+    /**
+     * A list of permitted actions the Role is authorized to take with the provided Resource. You can use `*`
+     * as a wildcard to grant a Role permission to use all possible actions related to the Resource.
+     */
     actions: string[];
 }
 export interface B2BRBACPolicyResponse {
@@ -30,7 +129,7 @@ export interface B2BRBACPolicyResponse {
     status_code: number;
     /**
      * The RBAC Policy document that contains all defined Roles and Resources – which are managed in the
-     * [Dashboard](/dashboard). Read more about these entities and how they work in our
+     * [Dashboard](/dashboard/rbac). Read more about these entities and how they work in our
      * [RBAC overview](https://stytch.com/docs/b2b/guides/rbac/overview).
      */
     policy?: Policy;
@@ -42,13 +141,13 @@ export declare class RBAC {
      * Get the active RBAC Policy for your current Stytch Project. An RBAC Policy is the canonical document
      * that stores all defined Resources and Roles within your RBAC permissioning model.
      *
-     * When using the backend SDKs, the RBAC Policy will automatically be loaded and refreshed in the
-     * background to allow for local evaluations, eliminating the need for an extra request to Stytch.
+     * When using the backend SDKs, the RBAC Policy will be cached to allow for local evaluations, eliminating
+     * the need for an extra request to Stytch. The policy will be refreshed if an authorization check is
+     * requested and the RBAC policy was last updated more than 5 minutes ago.
      *
-     * Resources and Roles can be created and managed within the [Dashboard](/dashboard). Additionally,
+     * Resources and Roles can be created and managed within the [Dashboard](/dashboard/rbac). Additionally,
      * [Role assignment](https://stytch.com/docs/b2b/guides/rbac/role-assignment) can be programmatically
      * managed through certain Stytch API endpoints.
-     *
      *
      * Check out the [RBAC overview](https://stytch.com/docs/b2b/guides/rbac/overview) to learn more about
      * Stytch's RBAC permissioning model.

--- a/types/lib/b2c/passwords.d.ts
+++ b/types/lib/b2c/passwords.d.ts
@@ -234,6 +234,15 @@ export interface PasswordsMigrateRequest {
      * behavior details.
      */
     untrusted_metadata?: Record<string, any>;
+    /**
+     * Whether to set the user's email as verified. This is a dangerous field. Incorrect use may lead to users
+     * getting erroneously
+     *                 deduplicated into one user object. This flag should only be set if you can attest that
+     * the user owns the email address in question.
+     *                 Access to this field is restricted. To enable it, please send us a note at
+     * support@stytch.com.
+     */
+    set_email_verified?: boolean;
     name?: Name;
 }
 export interface PasswordsMigrateResponse {


### PR DESCRIPTION
1. Docs updates
2. Adds support for `set_email_verified` in passwords/migrate