### PR TITLE
chore: Release 10.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "stytch",
-  "version": "10.5.0",
+  "version": "10.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stytch",
-  "version": "10.5.0",
+  "version": "10.6.0",
   "description": "A wrapper for the Stytch API",
   "types": "./types/lib/index.d.ts",
   "main": "./dist/index.js",


### PR DESCRIPTION
#297 bumped the version to `10.5.0` but `10.5.0` was already shipped as of https://github.com/stytchauth/stytch-node/pull/295. The version numbers were the same, so we didn't get a merge conflict. This also meant we didn't publish a version when we merged the PR. Let's increment the version and run it again!