### PR TITLE
(fix) Update rbac_implicit_role_assignments type in organization update

### DIFF
--- a/lib/b2b/organizations.ts
+++ b/lib/b2b/organizations.ts
@@ -802,7 +802,7 @@ export interface B2BOrganizationsUpdateRequest {
    * If this field is provided and a session header is passed into the request, the Member Session must have
    * permission to perform the `update.settings.implicit-roles` action on the `stytch.organization` Resource.
    */
-  rbac_email_implicit_role_assignments?: string[];
+  rbac_email_implicit_role_assignments?: EmailImplicitRoleAssignment[];
   /**
    * The setting that controls which MFA methods can be used by Members of an Organization. The accepted
    * values are:

--- a/test/b2b/organizations.test.ts
+++ b/test/b2b/organizations.test.ts
@@ -171,6 +171,33 @@ describe("organizations.update", () => {
       },
     });
   });
+
+  test("rbac_email_implicit_role_assignments", () => {
+    return expect(
+      organizations.update({
+        organization_id: "organization-id-1234",
+        email_allowed_domains: ["stytch.co", "example.io"],
+        rbac_email_implicit_role_assignments: [
+          {
+            domain: "stytch.co",
+            role_id: "stytch_admin",
+          },
+        ],
+      })
+    ).resolves.toMatchObject({
+      method: "PUT",
+      path: "/v1/b2b/organizations/organization-id-1234",
+      data: {
+        rbac_email_implicit_role_assignments: [
+          {
+            domain: "stytch.co",
+            role_id: "stytch_admin",
+          },
+        ],
+        email_allowed_domains: ["stytch.co", "example.io"],
+      },
+    });
+  });
 });
 
 describe("organizations.delete", () => {


### PR DESCRIPTION
This issue caused me a headache because the property is poorly documented in the [docs](https://stytch.com/docs/b2b/api/update-organization). There is no example for `rbac_email_implicit_role_assignments`.

The [error documentation](https://stytch.com/docs/b2b/api/errors/400#invalid_rbac_role_assignment) doesn't have a solution either.

When I tried to use the intended type (`string[]`), I got the following error:
```
/Users/acsraymund/code/my-project/node_modules/stytch/dist/shared/index.js:39
    throw new _errors.StytchError(responseJSON);
          ^
StytchError: {"status_code":400,"request_id":"request-id-test-3d6780f6-e858-4273-83b5-04ccf9cea7ee","error_type":"invalid_rbac_role_assignment","error_message":"The role assignment provided is not properly formatted. Make sure both a domain and role_id are included.","error_url":"https://stytch.com/docs/b2b/api/errors/400#invalid_rbac_role_assignment"}
    at request (/Users/acsraymund/code/my-project/node_modules/stytch/dist/shared/index.js:39:11)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async main (/Users/acsraymund/code/my-project/scripts/stytch-role-sync/src/rbac-email-implicit-role.ts:50:5) {
  status_code: 400,
  request_id: 'request-id-test-3d6780f6-e858-4273-83b5-04ccf9cea7ee',
  error_type: 'invalid_rbac_role_assignment',
  error_message: 'The role assignment provided is not properly formatted. Make sure both a domain and role_id are included.',
  error_url: 'https://stytch.com/docs/b2b/api/errors/400#invalid_rbac_role_assignment'
}
```

The error says: `The role assignment provided is not properly formatted. Make sure both a domain and role_id are included.`, but the typing said I have to add `string[]`. So I dig into the source code and I found the correct type is presented everywhere else. 😅

Small fix, I also added a test.