### PR TITLE
Convert OAuth2-style errors to StytchError equivalent

### DIFF
--- a/dist/shared/errors.js
+++ b/dist/shared/errors.js
@@ -7,11 +7,19 @@ exports.StytchError = exports.RequestError = exports.ClientError = void 0;
 class StytchError extends Error {
   constructor(data) {
     super(JSON.stringify(data));
-    this.status_code = data.status_code;
-    this.request_id = data.request_id;
-    this.error_type = data.error_type;
-    this.error_message = data.error_message;
-    this.error_url = data.error_url;
+    if ("error" in data) {
+      this.status_code = data.status_code;
+      this.request_id = data.request_id;
+      this.error_type = data.error;
+      this.error_message = data.error_description;
+      this.error_url = data.error_uri;
+    } else {
+      this.status_code = data.status_code;
+      this.request_id = data.request_id;
+      this.error_type = data.error_type;
+      this.error_message = data.error_message;
+      this.error_url = data.error_url;
+    }
   }
 }
 exports.StytchError = StytchError;

--- a/lib/shared/errors.ts
+++ b/lib/shared/errors.ts
@@ -8,6 +8,14 @@ export interface StytchErrorJSON {
   error_url: string;
 }
 
+export interface OAuth2ErrorJSON {
+  status_code: number;
+  request_id: string;
+  error: string;
+  error_description: string;
+  error_uri: string;
+}
+
 export class StytchError extends Error {
   status_code: number;
   request_id: string;
@@ -15,13 +23,21 @@ export class StytchError extends Error {
   error_message: string;
   error_url: string;
 
-  constructor(data: StytchErrorJSON) {
+  constructor(data: StytchErrorJSON | OAuth2ErrorJSON) {
     super(JSON.stringify(data));
-    this.status_code = data.status_code;
-    this.request_id = data.request_id;
-    this.error_type = data.error_type;
-    this.error_message = data.error_message;
-    this.error_url = data.error_url;
+    if ("error" in data) {
+      this.status_code = data.status_code;
+      this.request_id = data.request_id;
+      this.error_type = data.error;
+      this.error_message = data.error_description;
+      this.error_url = data.error_uri;
+    } else {
+      this.status_code = data.status_code;
+      this.request_id = data.request_id;
+      this.error_type = data.error_type;
+      this.error_message = data.error_message;
+      this.error_url = data.error_url;
+    }
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stytch",
-  "version": "10.15.0",
+  "version": "10.15.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "stytch",
-      "version": "10.15.0",
+      "version": "10.15.1",
       "license": "MIT",
       "dependencies": {
         "jose": "^4.14.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stytch",
-  "version": "10.15.0",
+  "version": "10.15.1",
   "description": "A wrapper for the Stytch API",
   "types": "./types/lib/index.d.ts",
   "main": "./dist/index.js",

--- a/types/lib/shared/errors.d.ts
+++ b/types/lib/shared/errors.d.ts
@@ -6,13 +6,20 @@ export interface StytchErrorJSON {
     error_message: string;
     error_url: string;
 }
+export interface OAuth2ErrorJSON {
+    status_code: number;
+    request_id: string;
+    error: string;
+    error_description: string;
+    error_uri: string;
+}
 export declare class StytchError extends Error {
     status_code: number;
     request_id: string;
     error_type: string;
     error_message: string;
     error_url: string;
-    constructor(data: StytchErrorJSON);
+    constructor(data: StytchErrorJSON | OAuth2ErrorJSON);
 }
 export declare class RequestError extends Error {
     request: requestConfig;


### PR DESCRIPTION
Fixes #314

The issue is that the M2M token endpoint conforms to OAuth2-expected field names, which meant they didn't match our existing names from a StytchError -- since an end-user wouldn't particularly care about this difference when using the backend SDK, this PR simply converts the field names from the OAuth2 names to our StytchError names.

# Testing
I created a simple script locally to create an M2M client and then try to get a token using a bogus client_secret.
Excerpt below:
![image](https://github.com/stytchauth/stytch-node/assets/119902778/5b5b0e8f-3412-4a72-a3e6-59d860e74f9c)
