### PR TITLE
Add clock_tolerance_seconds to M2M token authentication

### DIFF
--- a/dist/b2c/m2m.js
+++ b/dist/b2c/m2m.js
@@ -116,7 +116,8 @@ class M2M {
       scope,
       custom_claims
     } = await (0, _sessions.authenticateM2MJwtLocal)(this.jwksClient, this.jwtOptions, data.access_token, {
-      max_token_age_seconds: data.max_token_age_seconds
+      max_token_age_seconds: data.max_token_age_seconds,
+      clock_tolerance_seconds: data.clock_tolerance_seconds
     });
     const scopes = scope.split(" ");
     if (data.required_scopes && data.required_scopes.length > 0) {

--- a/lib/b2c/m2m.ts
+++ b/lib/b2c/m2m.ts
@@ -262,7 +262,10 @@ export class M2M {
       this.jwksClient,
       this.jwtOptions,
       data.access_token,
-      { max_token_age_seconds: data.max_token_age_seconds, clock_tolerance_seconds: data.clock_tolerance_seconds }
+      {
+        max_token_age_seconds: data.max_token_age_seconds,
+        clock_tolerance_seconds: data.clock_tolerance_seconds,
+      }
     );
     const scopes = scope.split(" ");
 

--- a/lib/b2c/m2m.ts
+++ b/lib/b2c/m2m.ts
@@ -131,6 +131,7 @@ export interface AuthenticateTokenRequest {
   access_token: string;
   required_scopes?: string[];
   max_token_age_seconds?: number;
+  clock_tolerance_seconds?: number;
 }
 
 export interface AuthenticateTokenResponse {
@@ -261,7 +262,7 @@ export class M2M {
       this.jwksClient,
       this.jwtOptions,
       data.access_token,
-      { max_token_age_seconds: data.max_token_age_seconds }
+      { max_token_age_seconds: data.max_token_age_seconds, clock_tolerance_seconds: data.clock_tolerance_seconds }
     );
     const scopes = scope.split(" ");
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stytch",
-  "version": "10.18.0",
+  "version": "10.19.0",
   "description": "A wrapper for the Stytch API",
   "types": "./types/lib/index.d.ts",
   "main": "./dist/index.js",

--- a/types/lib/b2c/m2m.d.ts
+++ b/types/lib/b2c/m2m.d.ts
@@ -82,6 +82,7 @@ export interface AuthenticateTokenRequest {
     access_token: string;
     required_scopes?: string[];
     max_token_age_seconds?: number;
+    clock_tolerance_seconds?: number;
 }
 export interface AuthenticateTokenResponse {
     client_id: string;


### PR DESCRIPTION
We occasionally see JWT validation errors with the `nbf` claim that may be due to clock skew. This PR adds the `clock_tolerance_seconds` parameter to the M2M token authentication method (it already existed for the local authentication method) to allow for some clock drift.