### PR TITLE
chore: Bump dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stytch",
-  "version": "11.1.0",
+  "version": "11.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "stytch",
-      "version": "11.1.0",
+      "version": "11.2.0",
       "license": "MIT",
       "dependencies": {
         "jose": "^5.6.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "11.1.0",
       "license": "MIT",
       "dependencies": {
-        "jose": "^4.14.6",
-        "undici": "^5.25.4"
+        "jose": "^5.6.3",
+        "undici": "^6.19.5"
       },
       "devDependencies": {
         "@babel/cli": "^7.23.0",
@@ -2125,14 +2125,6 @@
       },
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
-      }
-    },
-    "node_modules/@fastify/busboy": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.0.0.tgz",
-      "integrity": "sha512-JUFJad5lv7jxj926GPgymrWQxxjPYuJNiNjNMzqT+HiuP6Vl3dk5xzG+8sTX96np0ZAluvaMzPsjhHZ5rNuNQQ==",
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -5246,9 +5238,9 @@
       }
     },
     "node_modules/jose": {
-      "version": "4.15.5",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.5.tgz",
-      "integrity": "sha512-jc7BFxgKPKi94uOvEmzlSWFFe2+vASyXaKUpdQKatWAESU2MWjDfFf0fdfc83CDKcA5QecabZeNLyfhe3yKNkg==",
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.6.3.tgz",
+      "integrity": "sha512-1Jh//hEEwMhNYPDDLwXHa2ePWgWiFNNUadVmguAAw2IJ6sj9mNxV5tGXJNqlMkJAybF6Lgw1mISDxTePP/187g==",
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -6484,14 +6476,11 @@
       }
     },
     "node_modules/undici": {
-      "version": "5.28.4",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.4.tgz",
-      "integrity": "sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==",
-      "dependencies": {
-        "@fastify/busboy": "^2.0.0"
-      },
+      "version": "6.19.5",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.19.5.tgz",
+      "integrity": "sha512-LryC15SWzqQsREHIOUybavaIHF5IoL0dJ9aWWxL/PgT1KfqAW5225FZpDUFlt9xiDMS2/S7DOKhFWA7RLksWdg==",
       "engines": {
-        "node": ">=14.0"
+        "node": ">=18.17"
       }
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
@@ -8221,11 +8210,6 @@
         "minimatch": "^3.0.4",
         "strip-json-comments": "^3.1.1"
       }
-    },
-    "@fastify/busboy": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.0.0.tgz",
-      "integrity": "sha512-JUFJad5lv7jxj926GPgymrWQxxjPYuJNiNjNMzqT+HiuP6Vl3dk5xzG+8sTX96np0ZAluvaMzPsjhHZ5rNuNQQ=="
     },
     "@humanwhocodes/config-array": {
       "version": "0.5.0",
@@ -10580,9 +10564,9 @@
       }
     },
     "jose": {
-      "version": "4.15.5",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.5.tgz",
-      "integrity": "sha512-jc7BFxgKPKi94uOvEmzlSWFFe2+vASyXaKUpdQKatWAESU2MWjDfFf0fdfc83CDKcA5QecabZeNLyfhe3yKNkg=="
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.6.3.tgz",
+      "integrity": "sha512-1Jh//hEEwMhNYPDDLwXHa2ePWgWiFNNUadVmguAAw2IJ6sj9mNxV5tGXJNqlMkJAybF6Lgw1mISDxTePP/187g=="
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -11473,12 +11457,9 @@
       "dev": true
     },
     "undici": {
-      "version": "5.28.4",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.4.tgz",
-      "integrity": "sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==",
-      "requires": {
-        "@fastify/busboy": "^2.0.0"
-      }
+      "version": "6.19.5",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.19.5.tgz",
+      "integrity": "sha512-LryC15SWzqQsREHIOUybavaIHF5IoL0dJ9aWWxL/PgT1KfqAW5225FZpDUFlt9xiDMS2/S7DOKhFWA7RLksWdg=="
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -50,8 +50,8 @@
     "typescript": "^4.4.3"
   },
   "dependencies": {
-    "jose": "^4.14.6",
-    "undici": "^5.25.4"
+    "jose": "^5.6.3",
+    "undici": "^6.19.5"
   },
   "eslintConfig": {
     "extends": "airbnb",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stytch",
-  "version": "11.1.0",
+  "version": "11.2.0",
   "description": "A wrapper for the Stytch API",
   "types": "./types/lib/index.d.ts",
   "main": "./dist/index.js",


### PR DESCRIPTION
Bumps `undici` and `jose` to latest. Not sure why Dependabot didn't do this for us?