### PR TITLE
feat: [AUTH-4057] Clean up dependecy on DOM type usage

### DIFF
--- a/dist/shared/index.js
+++ b/dist/shared/index.js
@@ -24,10 +24,8 @@ async function request(fetchConfig, requestConfig) {
     response = await fetch(url.toString(), {
       method: requestConfig.method,
       body: body,
-      // [AUTH-2047] things fail catastrophically when using the NextJS fetch-cache
-      // so we need to explicitly opt out of it using the "no-store" tag
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
+      // @ts-expect-error [AUTH-2047] things fail catastrophically when using the NextJS fetch-cache
+      // so we need to explicitly opt out of it using the "no-store" tag - which isn't part of the core Node fetch API
       cache: "no-store",
       ...fetchConfig,
       headers: finalHeaders

--- a/dist/shared/index.js
+++ b/dist/shared/index.js
@@ -24,6 +24,10 @@ async function request(fetchConfig, requestConfig) {
     response = await fetch(url.toString(), {
       method: requestConfig.method,
       body: body,
+      // [AUTH-2047] things fail catastrophically when using the NextJS fetch-cache
+      // so we need to explicitly opt out of it using the "no-store" tag
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
       cache: "no-store",
       ...fetchConfig,
       headers: finalHeaders

--- a/lib/shared/index.ts
+++ b/lib/shared/index.ts
@@ -1,4 +1,4 @@
-import type { Dispatcher } from "undici";
+import type { Dispatcher, BodyInit } from "undici";
 import { RequestError, StytchError, StytchErrorJSON } from "./errors";
 
 export interface fetchConfig {
@@ -41,6 +41,10 @@ export async function request<T>(
     response = await fetch(url.toString(), {
       method: requestConfig.method,
       body: body,
+      // [AUTH-2047] things fail catastrophically when using the NextJS fetch-cache
+      // so we need to explicitly opt out of it using the "no-store" tag
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
       cache: "no-store",
       ...fetchConfig,
       headers: finalHeaders,

--- a/lib/shared/index.ts
+++ b/lib/shared/index.ts
@@ -41,10 +41,8 @@ export async function request<T>(
     response = await fetch(url.toString(), {
       method: requestConfig.method,
       body: body,
-      // [AUTH-2047] things fail catastrophically when using the NextJS fetch-cache
-      // so we need to explicitly opt out of it using the "no-store" tag
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
+      // @ts-expect-error [AUTH-2047] things fail catastrophically when using the NextJS fetch-cache
+      // so we need to explicitly opt out of it using the "no-store" tag - which isn't part of the core Node fetch API
       cache: "no-store",
       ...fetchConfig,
       headers: finalHeaders,

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "stytch",
-      "version": "11.4.0",
+      "version": "11.4.1",
       "license": "MIT",
       "dependencies": {
         "jose": "^5.6.3",
@@ -18,14 +18,14 @@
         "@babel/preset-env": "^7.22.20",
         "@babel/preset-typescript": "^7.23.0",
         "@types/jest": "^29.5.5",
-        "@types/node": "^18.18.3",
+        "@types/node": "^22.5.1",
         "@typescript-eslint/eslint-plugin": "^4.33.0",
         "@typescript-eslint/parser": "^4.33.0",
         "eslint": "^7.32.0",
         "jest": "^29.7.0",
         "prettier": "2.4.1",
         "ts-jest": "^29.1.1",
-        "typescript": "^4.4.3"
+        "typescript": "^5.5.4"
       },
       "engines": {
         "node": ">= 18.0.0"
@@ -87,10 +87,11 @@
       }
     },
     "node_modules/@babel/cli/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "dev": true,
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver"
       }
@@ -2673,10 +2674,14 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.18.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.3.tgz",
-      "integrity": "sha512-0OVfGupTl3NBFr8+iXpfZ8NR7jfFO+P1Q+IO/q0wbo02wYkP5gy36phojeYWpLQ6WAMjl+VfmqUk2YbUfp0irA==",
-      "dev": true
+      "version": "22.5.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.5.1.tgz",
+      "integrity": "sha512-KkHsxej0j9IW1KKOOAA/XBA0z08UFSrRQHErzEfA3Vgq57eXIMYboIlHJuYIfd+lwCQjtKqUu3UnmKbtUc9yRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.19.2"
+      }
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.1",
@@ -2741,13 +2746,11 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/semver": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -2882,13 +2885,11 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -3809,13 +3810,11 @@
       }
     },
     "node_modules/eslint/node_modules/semver": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -5458,13 +5457,14 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
-      "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "braces": "^3.0.1",
-        "picomatch": "^2.2.3"
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
       },
       "engines": {
         "node": ">=8.6"
@@ -5692,10 +5692,11 @@
       "dev": true
     },
     "node_modules/picomatch": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
-      "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8.6"
       },
@@ -6463,16 +6464,17 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
-      "integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==",
+      "version": "5.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
+      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/undici": {
@@ -6482,6 +6484,13 @@
       "engines": {
         "node": ">=18.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",
@@ -6613,10 +6622,11 @@
       }
     },
     "node_modules/word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6751,9 +6761,9 @@
           }
         },
         "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "version": "5.7.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+          "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
           "dev": true
         },
         "slash": {
@@ -8670,10 +8680,13 @@
       "dev": true
     },
     "@types/node": {
-      "version": "18.18.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.3.tgz",
-      "integrity": "sha512-0OVfGupTl3NBFr8+iXpfZ8NR7jfFO+P1Q+IO/q0wbo02wYkP5gy36phojeYWpLQ6WAMjl+VfmqUk2YbUfp0irA==",
-      "dev": true
+      "version": "22.5.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.5.1.tgz",
+      "integrity": "sha512-KkHsxej0j9IW1KKOOAA/XBA0z08UFSrRQHErzEfA3Vgq57eXIMYboIlHJuYIfd+lwCQjtKqUu3UnmKbtUc9yRw==",
+      "dev": true,
+      "requires": {
+        "undici-types": "~6.19.2"
+      }
     },
     "@types/stack-utils": {
       "version": "2.0.1",
@@ -8719,13 +8732,10 @@
           "dev": true
         },
         "semver": {
-          "version": "7.3.5",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
+          "version": "7.6.3",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+          "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+          "dev": true
         }
       }
     },
@@ -8798,13 +8808,10 @@
       },
       "dependencies": {
         "semver": {
-          "version": "7.3.5",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
+          "version": "7.6.3",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+          "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+          "dev": true
         }
       }
     },
@@ -9453,13 +9460,10 @@
           }
         },
         "semver": {
-          "version": "7.3.5",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
+          "version": "7.6.3",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+          "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+          "dev": true
         }
       }
     },
@@ -10738,13 +10742,13 @@
       "dev": true
     },
     "micromatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
-      "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
       "requires": {
-        "braces": "^3.0.1",
-        "picomatch": "^2.2.3"
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
       }
     },
     "mimic-fn": {
@@ -10914,9 +10918,9 @@
       "dev": true
     },
     "picomatch": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
-      "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "dev": true
     },
     "pify": {
@@ -11451,15 +11455,21 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
-      "integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==",
+      "version": "5.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
+      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
       "dev": true
     },
     "undici": {
       "version": "6.19.5",
       "resolved": "https://registry.npmjs.org/undici/-/undici-6.19.5.tgz",
       "integrity": "sha512-LryC15SWzqQsREHIOUybavaIHF5IoL0dJ9aWWxL/PgT1KfqAW5225FZpDUFlt9xiDMS2/S7DOKhFWA7RLksWdg=="
+    },
+    "undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "dev": true
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",
@@ -11552,9 +11562,9 @@
       }
     },
     "word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true
     },
     "wrap-ansi": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@babel/preset-env": "^7.22.20",
         "@babel/preset-typescript": "^7.23.0",
         "@types/jest": "^29.5.5",
-        "@types/node": "^22.5.1",
+        "@types/node": "^20.14.8",
         "@typescript-eslint/eslint-plugin": "^4.33.0",
         "@typescript-eslint/parser": "^4.33.0",
         "eslint": "^7.32.0",
@@ -2674,13 +2674,13 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "22.5.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.5.1.tgz",
-      "integrity": "sha512-KkHsxej0j9IW1KKOOAA/XBA0z08UFSrRQHErzEfA3Vgq57eXIMYboIlHJuYIfd+lwCQjtKqUu3UnmKbtUc9yRw==",
+      "version": "20.14.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.8.tgz",
+      "integrity": "sha512-DO+2/jZinXfROG7j7WKFn/3C6nFwxy2lLpgLjEXJz+0XKphZlTLJ14mo8Vfg8X5BWN6XjyESXq+LcYdT7tR3bA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.19.2"
+        "undici-types": "~5.26.4"
       }
     },
     "node_modules/@types/stack-utils": {
@@ -6486,9 +6486,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "dev": true,
       "license": "MIT"
     },
@@ -8680,12 +8680,12 @@
       "dev": true
     },
     "@types/node": {
-      "version": "22.5.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.5.1.tgz",
-      "integrity": "sha512-KkHsxej0j9IW1KKOOAA/XBA0z08UFSrRQHErzEfA3Vgq57eXIMYboIlHJuYIfd+lwCQjtKqUu3UnmKbtUc9yRw==",
+      "version": "20.14.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.8.tgz",
+      "integrity": "sha512-DO+2/jZinXfROG7j7WKFn/3C6nFwxy2lLpgLjEXJz+0XKphZlTLJ14mo8Vfg8X5BWN6XjyESXq+LcYdT7tR3bA==",
       "dev": true,
       "requires": {
-        "undici-types": "~6.19.2"
+        "undici-types": "~5.26.4"
       }
     },
     "@types/stack-utils": {
@@ -11466,9 +11466,9 @@
       "integrity": "sha512-LryC15SWzqQsREHIOUybavaIHF5IoL0dJ9aWWxL/PgT1KfqAW5225FZpDUFlt9xiDMS2/S7DOKhFWA7RLksWdg=="
     },
     "undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "dev": true
     },
     "unicode-canonical-property-names-ecmascript": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stytch",
-  "version": "11.4.1",
+  "version": "11.4.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "stytch",
-      "version": "11.4.1",
+      "version": "11.4.2",
       "license": "MIT",
       "dependencies": {
         "jose": "^5.6.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stytch",
-  "version": "11.4.1",
+  "version": "11.4.2",
   "description": "A wrapper for the Stytch API",
   "types": "./types/lib/index.d.ts",
   "main": "./dist/index.js",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@babel/preset-env": "^7.22.20",
     "@babel/preset-typescript": "^7.23.0",
     "@types/jest": "^29.5.5",
-    "@types/node": "^22.5.1",
+    "@types/node": "^20.14.8",
     "@typescript-eslint/eslint-plugin": "^4.33.0",
     "@typescript-eslint/parser": "^4.33.0",
     "eslint": "^7.32.0",

--- a/package.json
+++ b/package.json
@@ -40,14 +40,14 @@
     "@babel/preset-env": "^7.22.20",
     "@babel/preset-typescript": "^7.23.0",
     "@types/jest": "^29.5.5",
-    "@types/node": "^18.18.3",
+    "@types/node": "^22.5.1",
     "@typescript-eslint/eslint-plugin": "^4.33.0",
     "@typescript-eslint/parser": "^4.33.0",
     "eslint": "^7.32.0",
     "jest": "^29.7.0",
     "prettier": "2.4.1",
     "ts-jest": "^29.1.1",
-    "typescript": "^4.4.3"
+    "typescript": "^5.5.4"
   },
   "dependencies": {
     "jose": "^5.6.3",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "target": "ES2015",
     "module": "commonjs",
-    "lib": ["DOM", "es2015"],
+    "lib": ["es2020"],
     "types": ["node"],
     "allowJs": true,
     "strict": true,

--- a/types/lib/b2b/organizations.d.ts
+++ b/types/lib/b2b/organizations.d.ts
@@ -911,7 +911,7 @@ export interface B2BOrganizationsUpdateResponse {
      */
     status_code: number;
 }
-export declare type OrganizationSearchOperand = {
+export type OrganizationSearchOperand = {
     filter_name: "organization_ids";
     filter_value: string[];
 } | {
@@ -936,7 +936,7 @@ export declare type OrganizationSearchOperand = {
     filter_name: "allowed_domain_fuzzy";
     filter_value: string;
 };
-export declare type MemberSearchOperand = {
+export type MemberSearchOperand = {
     filter_name: "member_ids";
     filter_value: string[];
 } | {
@@ -958,7 +958,7 @@ export declare type MemberSearchOperand = {
     filter_name: "member_phone_number_fuzzy";
     filter_value: string;
 };
-export declare type SearchQueryOperand = OrganizationSearchOperand | MemberSearchOperand | {
+export type SearchQueryOperand = OrganizationSearchOperand | MemberSearchOperand | {
     filter_name: string;
     [key: string]: unknown;
 };

--- a/types/lib/b2b/organizations_members_oauth_providers.d.ts
+++ b/types/lib/b2b/organizations_members_oauth_providers.d.ts
@@ -106,7 +106,7 @@ export interface B2BOrganizationsMembersOAuthProvidersProviderInformationRequest
 /**
  * @deprecated Since version 10.11.0. Please use {@link B2BOrganizationsMembersOAuthProvidersProviderInformationRequest} instead.
  */
-export declare type B2BOrganizationsMembersOAuthProvidersMicrosoftRequest = B2BOrganizationsMembersOAuthProvidersProviderInformationRequest;
+export type B2BOrganizationsMembersOAuthProvidersMicrosoftRequest = B2BOrganizationsMembersOAuthProvidersProviderInformationRequest;
 export declare class OAuthProviders {
     private fetchConfig;
     constructor(fetchConfig: fetchConfig);

--- a/types/lib/b2c/m2m.d.ts
+++ b/types/lib/b2c/m2m.d.ts
@@ -68,7 +68,7 @@ export interface M2MSearchQuery {
      */
     operands: M2MSearchQueryOperand[];
 }
-export declare type M2MSearchQueryOperand = {
+export type M2MSearchQueryOperand = {
     filter_name: "client_id";
     filter_value: string[];
 } | {

--- a/types/lib/b2c/m2m_local.d.ts
+++ b/types/lib/b2c/m2m_local.d.ts
@@ -1,4 +1,4 @@
-export declare type ScopeAuthorizationFunc = ({ hasScopes, requiredScopes, }: {
+export type ScopeAuthorizationFunc = ({ hasScopes, requiredScopes, }: {
     hasScopes: string[];
     requiredScopes: string[];
 }) => boolean;

--- a/types/lib/b2c/users.d.ts
+++ b/types/lib/b2c/users.d.ts
@@ -535,7 +535,7 @@ export interface UsersUpdateResponse {
      */
     status_code: number;
 }
-export declare type SearchUsersQueryOperand = {
+export type SearchUsersQueryOperand = {
     filter_name: "created_at_greater_than";
     filter_value: string;
 } | {

--- a/types/lib/shared/index.d.ts
+++ b/types/lib/shared/index.d.ts
@@ -1,11 +1,11 @@
-import type { Dispatcher } from "undici";
+import type { Dispatcher, BodyInit } from "undici";
 export interface fetchConfig {
     baseURL: string;
     headers: Record<string, string>;
     timeout: number;
     dispatcher?: Dispatcher;
 }
-export declare type requestConfig = {
+export type requestConfig = {
     url: string;
     method: "GET" | "DELETE" | "POST" | "PUT";
     params?: Record<string, string | number | boolean | undefined>;

--- a/types/lib/shared/sessions.d.ts
+++ b/types/lib/shared/sessions.d.ts
@@ -3,7 +3,7 @@ export interface JwtConfig {
     projectID: string;
     jwks: jose.JWTVerifyGetKey;
 }
-declare type IntermediateSession = {
+type IntermediateSession = {
     sub: string;
     session_id: string;
     attributes: unknown;


### PR DESCRIPTION
This PR:
- eliminates the use of `DOM` in `tsconfig.json` - previously we required all callers to either also have `DOM` or to disable library typechecking
- Updates `@types/node` and `typescript` to latest
- Starts to import the `BodyInit` type from `undici` 

No runtime code changes are made