### PR TITLE
fix: improve build compatibility

### DIFF
--- a/module.mjs
+++ b/module.mjs
@@ -1,1 +1,0 @@
-export * from "./dist/index.js";

--- a/package.json
+++ b/package.json
@@ -4,15 +4,15 @@
   "description": "A wrapper for the Stytch API",
   "types": "./types/lib/index.d.ts",
   "main": "./dist/index.js",
+  "type": "commonjs",
   "exports": {
+    "types": "./types/lib/index.d.ts",
     "require": "./dist/index.js",
-    "import": "./module.mjs",
-    "types": "./types/lib/index.d.ts"
+    "default": "./dist/index.js"
   },
   "files": [
     "dist/**/*",
-    "types/**/*",
-    "module.mjs"
+    "types/**/*"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
Make some improvements to package.json:
- Add `type: "commonjs"` to explicitly declare the package to be CJS
- Remove `exports.import`, since it was just referencing an ESM file that re-exported the CJS entrypoint. This caused issues with at least vite's dev mode. Replace it with a `default` export that (also) points to the CJS module.
- Move the `types` export to be first, so that it can be resolved by TypeScript with the correct priority.