### PR TITLE
fix: improve build compatibility

### DIFF
--- a/module.mjs
+++ b/module.mjs
@@ -1,1 +1,0 @@
-export * from "./dist/index.js";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stytch",
-  "version": "12.12.1",
+  "version": "12.12.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "stytch",
-      "version": "12.12.1",
+      "version": "12.12.2",
       "license": "MIT",
       "dependencies": {
         "jose": "^5.6.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stytch",
-  "version": "12.12.1",
+  "version": "12.12.2",
   "description": "A wrapper for the Stytch API",
   "types": "./types/lib/index.d.ts",
   "main": "./dist/index.js",

--- a/package.json
+++ b/package.json
@@ -4,15 +4,15 @@
   "description": "A wrapper for the Stytch API",
   "types": "./types/lib/index.d.ts",
   "main": "./dist/index.js",
+  "type": "commonjs",
   "exports": {
+    "types": "./types/lib/index.d.ts",
     "require": "./dist/index.js",
-    "import": "./module.mjs",
-    "types": "./types/lib/index.d.ts"
+    "default": "./dist/index.js"
   },
   "files": [
     "dist/**/*",
-    "types/**/*",
-    "module.mjs"
+    "types/**/*"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
New build entrypoint has been published as `stytch@12.11.2-alpha.0` and validated in the following runtimes:
- Node (`import` and `require`)
- Deno
- Bun
- NextJS Edge
- Cloudflare Workers
- Cloudflare Workers + Vite

Closes #368