### PR TITLE
Update stytch-node SDK to pass through error_details

### DIFF
--- a/dist/shared/errors.js
+++ b/dist/shared/errors.js
@@ -19,6 +19,7 @@ class StytchError extends Error {
       this.error_type = data.error_type;
       this.error_message = data.error_message;
       this.error_url = data.error_url;
+      this.error_details = data.error_details;
     }
   }
 }

--- a/lib/shared/errors.ts
+++ b/lib/shared/errors.ts
@@ -6,6 +6,7 @@ export interface StytchErrorJSON {
   error_type: string;
   error_message: string;
   error_url: string;
+  error_details: Map<string, string> | undefined;
 }
 
 export interface OAuth2ErrorJSON {
@@ -22,6 +23,7 @@ export class StytchError extends Error {
   error_type: string;
   error_message: string;
   error_url: string;
+  error_details: Map<string, string> | undefined;
 
   constructor(data: StytchErrorJSON | OAuth2ErrorJSON) {
     super(JSON.stringify(data));
@@ -37,6 +39,7 @@ export class StytchError extends Error {
       this.error_type = data.error_type;
       this.error_message = data.error_message;
       this.error_url = data.error_url;
+      this.error_details = data.error_details;
     }
   }
 }

--- a/types/lib/shared/errors.d.ts
+++ b/types/lib/shared/errors.d.ts
@@ -5,6 +5,7 @@ export interface StytchErrorJSON {
     error_type: string;
     error_message: string;
     error_url: string;
+    error_details: Map<string, string> | undefined;
 }
 export interface OAuth2ErrorJSON {
     status_code: number;
@@ -19,6 +20,7 @@ export declare class StytchError extends Error {
     error_type: string;
     error_message: string;
     error_url: string;
+    error_details: Map<string, string> | undefined;
     constructor(data: StytchErrorJSON | OAuth2ErrorJSON);
 }
 export declare class RequestError extends Error {


### PR DESCRIPTION
StytchErrors can have error_details on them, but those were not being passed through to the SDK. This change adds them to the error in the stytch-node SDK.

Testing:
You can test this for the `invalid_email_for_jit_provisioning` error that happens when trying to do a magic link or OTP loginOrSignup request when your email is not part of the allowed domains. This is the error after the changes, from a test app:
<img width="1205" alt="Screenshot 2025-04-14 at 2 29 24 PM" src="https://github.com/user-attachments/assets/5968a132-7994-4da1-beab-830787eb2f02" />
