### PR TITLE
Add claimed domains filter to B2B organization search

### DIFF
--- a/lib/b2b/organizations.ts
+++ b/lib/b2b/organizations.ts
@@ -1173,7 +1173,11 @@ export type OrganizationSearchOperand =
   | {
       filter_name: "allowed_domain_fuzzy";
       filter_value: string;
-    };
+    }
+  | {
+      filter_name: "claimed_email_domains";
+      filter_value: string[];
+  };
 
 export type MemberSearchOperand =
   | {

--- a/lib/b2b/organizations.ts
+++ b/lib/b2b/organizations.ts
@@ -1177,7 +1177,7 @@ export type OrganizationSearchOperand =
   | {
       filter_name: "claimed_email_domains";
       filter_value: string[];
-  };
+    };
 
 export type MemberSearchOperand =
   | {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stytch",
-  "version": "12.15.0",
+  "version": "12.16.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "stytch",
-      "version": "12.15.0",
+      "version": "12.16.0",
       "license": "MIT",
       "dependencies": {
         "jose": "^5.6.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stytch",
-  "version": "12.15.0",
+  "version": "12.16.0",
   "description": "A wrapper for the Stytch API",
   "types": "./types/lib/index.d.ts",
   "main": "./dist/index.js",

--- a/types/lib/b2b/organizations.d.ts
+++ b/types/lib/b2b/organizations.d.ts
@@ -1064,6 +1064,9 @@ export type OrganizationSearchOperand = {
 } | {
     filter_name: "allowed_domain_fuzzy";
     filter_value: string;
+} | {
+    filter_name: "claimed_email_domains";
+    filter_value: string[];
 };
 export type MemberSearchOperand = {
     filter_name: "member_ids";


### PR DESCRIPTION
The Node SDK will accept arbitrary strings for the `filter_name` in the B2B organization search endpoint, so you don't technically have to upgrade to search by claimed domain. This PR adds the `claimed_email_domains` filter to the nice string type for the search operand as a minor update.