### PR TITLE
Add Roles to Consumer Session Model

### DIFF
--- a/dist/b2c/sessions.js
+++ b/dist/b2c/sessions.js
@@ -296,7 +296,8 @@ class Sessions {
       started_at: sess.started_at,
       last_accessed_at: sess.last_accessed_at,
       expires_at: sess.expires_at,
-      custom_claims: sess.custom_claims
+      custom_claims: sess.custom_claims,
+      roles: sess.roles
     };
   }
   // ENDMANUAL(authenticateJwt)

--- a/lib/b2c/sessions.ts
+++ b/lib/b2c/sessions.ts
@@ -407,6 +407,7 @@ export interface Session {
   user_id: string;
   // An array of different authentication factors that comprise a Session.
   authentication_factors: AuthenticationFactor[];
+  roles: string[];
   /**
    * The timestamp when the Session was created. Values conform to the RFC 3339 standard and are expressed in
    * UTC, e.g. `2021-12-29T12:33:09Z`.
@@ -1224,6 +1225,7 @@ export class Sessions {
       last_accessed_at: sess.last_accessed_at,
       expires_at: sess.expires_at,
       custom_claims: sess.custom_claims,
+      roles: sess.roles,
     };
   }
   // ENDMANUAL(authenticateJwt)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stytch",
-  "version": "13.0.0",
+  "version": "12.40.0",
   "description": "A wrapper for the Stytch API",
   "types": "./types/lib/index.d.ts",
   "main": "./dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stytch",
-  "version": "12.39.0",
+  "version": "13.0.0",
   "description": "A wrapper for the Stytch API",
   "types": "./types/lib/index.d.ts",
   "main": "./dist/index.js",

--- a/types/lib/b2c/sessions.d.ts
+++ b/types/lib/b2c/sessions.d.ts
@@ -257,6 +257,7 @@ export interface Session {
     session_id: string;
     user_id: string;
     authentication_factors: AuthenticationFactor[];
+    roles: string[];
     /**
      * The timestamp when the Session was created. Values conform to the RFC 3339 standard and are expressed in
      * UTC, e.g. `2021-12-29T12:33:09Z`.


### PR DESCRIPTION
This adds roles to the consumer session model type. This is a list of strings.

This is a major version increase due to adding a non-optional field.