### PR TITLE
Provide auth check to the authenticate network call

### DIFF
--- a/lib/b2c/sessions.ts
+++ b/lib/b2c/sessions.ts
@@ -1174,7 +1174,10 @@ export class Sessions {
       };
     } catch (err) {
       // JWT could not be verified locally. Check with the Stytch API.
-      return this.authenticate({ session_jwt: params.session_jwt });
+      return this.authenticate({
+        session_jwt: params.session_jwt,
+        authorization_check: params.authorization_check,
+      });
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stytch",
-  "version": "12.42.0",
+  "version": "12.42.1",
   "description": "A wrapper for the Stytch API",
   "types": "./types/lib/index.d.ts",
   "main": "./dist/index.js",


### PR DESCRIPTION
In cases where we make a network call to authenticate a JWT (i.e. local fails), we were mistakenly not passing the authorization_check parameter through.