### PR TITLE
Fix publishing workflow

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -21,7 +21,7 @@ jobs:
           node-version: "22"
 
       - name: Upgrade npm (required for trusted publishing)
-        run: npm install -g npm@latest
+        run: npm install -g npm@~11.10.0
 
       - name: Install
         run: npm ci

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stytch",
-  "version": "13.2.4",
+  "version": "13.2.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "stytch",
-      "version": "13.2.4",
+      "version": "13.2.5",
       "license": "MIT",
       "dependencies": {
         "jose": "^5.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stytch",
-  "version": "13.2.4",
+  "version": "13.2.5",
   "description": "A wrapper for the Stytch API",
   "types": "./types/lib/index.d.ts",
   "main": "./dist/index.js",


### PR DESCRIPTION
Pinning `npm` to `11.10.0` as described in this github issue - https://github.com/npm/cli/issues/9151