### PR TITLE
Use git diff directly to check for changes to package.json

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -32,20 +32,17 @@ jobs:
           VERSION=$(node -e 'console.log(`v${require("./package.json").version}`)')
           echo "release_tag=$VERSION" >> $GITHUB_OUTPUT
 
-      - name: Get changed files
-        id: files
-        uses: jitterbit/get-changed-files@v1
-
       - name: Check for package.json diff
         id: diff
+        env:
+          BASE_SHA: ${{ github.event.before }}
+          HEAD_SHA: ${{ github.sha }}
         run: |
-          FOUND=0
-          for changed_file in ${{ steps.files.outputs.all }}; do
-            if [[ $changed_file == "package.json" ]]; then
-              FOUND=1
-            fi
-          done
-          echo "diff=$FOUND" >> $GITHUB_OUTPUT
+          if git diff --quiet "$BASE_SHA" "$HEAD_SHA" -- package.json; then
+            echo "diff=0" >> $GITHUB_OUTPUT
+          else
+            echo "diff=1" >> $GITHUB_OUTPUT
+          fi
 
       - name: Publish to NPM
         if: steps.diff.outputs.diff != 0


### PR DESCRIPTION
CC suggested these changes though I had to poke it a few times, I'm not familiar with GitHub env vars but I think they looked correct. This action only ran on push and the original action used these as the refs https://github.com/jitterbit/get-changed-files/blob/master/src/main.ts#L33 so I think the ones it picked are equivalent. 

See https://twilio.slack.com/archives/C0ATAGAMWBT/p1778023216143759 for context 