### PR TITLE
Support session_duration_minutes and session_custom_claims in authenticateJwt

### DIFF
--- a/dist/b2b/sessions.js
+++ b/dist/b2b/sessions.js
@@ -315,8 +315,23 @@ class Sessions {
    *
    * To force remote validation for all tokens, set max_token_age_seconds to zero or use the
    * authenticate method instead.
+   *
+   * The session_duration_minutes and session_custom_claims parameters are only applied when the
+   * session is authenticated remotely against the Stytch API. Local verification does not extend
+   * the session, so a JWT that verifies locally will ignore these values. To guarantee they are
+   * applied, set max_token_age_seconds to zero to force remote verification.
    */
   async authenticateJwt(params) {
+    // If max_token_age_seconds is explicitly zero, force remote verification so that
+    // session_duration_minutes and session_custom_claims are reliably applied.
+    if (params.max_token_age_seconds === 0) {
+      return this.authenticate({
+        session_jwt: params.session_jwt,
+        authorization_check: params.authorization_check,
+        session_duration_minutes: params.session_duration_minutes,
+        session_custom_claims: params.session_custom_claims
+      });
+    }
     try {
       const member_session = await this.authenticateJwtLocal(params);
       return {
@@ -327,7 +342,9 @@ class Sessions {
       // JWT could not be verified locally. Check with the Stytch API.
       return this.authenticate({
         session_jwt: params.session_jwt,
-        authorization_check: params.authorization_check
+        authorization_check: params.authorization_check,
+        session_duration_minutes: params.session_duration_minutes,
+        session_custom_claims: params.session_custom_claims
       });
     }
   }

--- a/dist/b2c/sessions.js
+++ b/dist/b2c/sessions.js
@@ -241,8 +241,23 @@ class Sessions {
    *
    * To force remote validation for all tokens, set max_token_age_seconds to zero or use the
    * authenticate method instead.
+   *
+   * The session_duration_minutes and session_custom_claims parameters are only applied when the
+   * session is authenticated remotely against the Stytch API. Local verification does not extend
+   * the session, so a JWT that verifies locally will ignore these values. To guarantee they are
+   * applied, set max_token_age_seconds to zero to force remote verification.
    */
   async authenticateJwt(params) {
+    // If max_token_age_seconds is explicitly zero, force remote verification so that
+    // session_duration_minutes and session_custom_claims are reliably applied.
+    if (params.max_token_age_seconds === 0) {
+      return this.authenticate({
+        session_jwt: params.session_jwt,
+        authorization_check: params.authorization_check,
+        session_duration_minutes: params.session_duration_minutes,
+        session_custom_claims: params.session_custom_claims
+      });
+    }
     try {
       const session = await this.authenticateJwtLocal(params);
       return {
@@ -253,7 +268,9 @@ class Sessions {
       // JWT could not be verified locally. Check with the Stytch API.
       return this.authenticate({
         session_jwt: params.session_jwt,
-        authorization_check: params.authorization_check
+        authorization_check: params.authorization_check,
+        session_duration_minutes: params.session_duration_minutes,
+        session_custom_claims: params.session_custom_claims
       });
     }
   }

--- a/lib/b2b/sessions.ts
+++ b/lib/b2b/sessions.ts
@@ -658,6 +658,20 @@ export interface B2BSessionsAuthenticateJwtRequest {
    * If explicitly set to zero, all tokens will be considered too old, even if they are otherwise valid.
    */
   max_token_age_seconds?: number;
+
+  /**
+   * Set the session lifetime to be this many minutes from now. This is only applied when the session is
+   * authenticated remotely against the Stytch API (i.e. when the JWT cannot be verified locally, or when
+   * remote verification is forced by setting `max_token_age_seconds` to zero). Local verification does not
+   * extend the session, so a JWT that verifies locally will ignore this value.
+   */
+  session_duration_minutes?: number;
+
+  /**
+   * Add a custom claims map to the Session being authenticated. As with `session_duration_minutes`, this is
+   * only applied when the session is authenticated remotely against the Stytch API.
+   */
+  session_custom_claims?: Record<string, any>; // eslint-disable-line @typescript-eslint/no-explicit-any
 }
 
 // Request type for `sessions.authenticateJwtLocal`
@@ -971,10 +985,26 @@ export class Sessions {
    *
    * To force remote validation for all tokens, set max_token_age_seconds to zero or use the
    * authenticate method instead.
+   *
+   * The session_duration_minutes and session_custom_claims parameters are only applied when the
+   * session is authenticated remotely against the Stytch API. Local verification does not extend
+   * the session, so a JWT that verifies locally will ignore these values. To guarantee they are
+   * applied, set max_token_age_seconds to zero to force remote verification.
    */
   async authenticateJwt(
     params: B2BSessionsAuthenticateJwtRequest
   ): Promise<{ member_session: MemberSession; session_jwt: string }> {
+    // If max_token_age_seconds is explicitly zero, force remote verification so that
+    // session_duration_minutes and session_custom_claims are reliably applied.
+    if (params.max_token_age_seconds === 0) {
+      return this.authenticate({
+        session_jwt: params.session_jwt,
+        authorization_check: params.authorization_check,
+        session_duration_minutes: params.session_duration_minutes,
+        session_custom_claims: params.session_custom_claims,
+      });
+    }
+
     try {
       const member_session = await this.authenticateJwtLocal(params);
       return {
@@ -986,6 +1016,8 @@ export class Sessions {
       return this.authenticate({
         session_jwt: params.session_jwt,
         authorization_check: params.authorization_check,
+        session_duration_minutes: params.session_duration_minutes,
+        session_custom_claims: params.session_custom_claims,
       });
     }
   }

--- a/lib/b2c/sessions.ts
+++ b/lib/b2c/sessions.ts
@@ -925,6 +925,20 @@ export interface SessionsAuthenticateJwtRequest {
    * If explicitly set to zero, all tokens will be considered too old, even if they are otherwise valid.
    */
   max_token_age_seconds?: number;
+
+  /**
+   * Set the session lifetime to be this many minutes from now. This is only applied when the session is
+   * authenticated remotely against the Stytch API (i.e. when the JWT cannot be verified locally, or when
+   * remote verification is forced by setting `max_token_age_seconds` to zero). Local verification does not
+   * extend the session, so a JWT that verifies locally will ignore this value.
+   */
+  session_duration_minutes?: number;
+
+  /**
+   * Add a custom claims map to the Session being authenticated. As with `session_duration_minutes`, this is
+   * only applied when the session is authenticated remotely against the Stytch API.
+   */
+  session_custom_claims?: Record<string, any>; // eslint-disable-line @typescript-eslint/no-explicit-any
 }
 
 // Request type for `sessions.authenticateJwtLocal`
@@ -1159,10 +1173,26 @@ export class Sessions {
    *
    * To force remote validation for all tokens, set max_token_age_seconds to zero or use the
    * authenticate method instead.
+   *
+   * The session_duration_minutes and session_custom_claims parameters are only applied when the
+   * session is authenticated remotely against the Stytch API. Local verification does not extend
+   * the session, so a JWT that verifies locally will ignore these values. To guarantee they are
+   * applied, set max_token_age_seconds to zero to force remote verification.
    */
   async authenticateJwt(
     params: SessionsAuthenticateJwtRequest
   ): Promise<{ session: Session; session_jwt: string }> {
+    // If max_token_age_seconds is explicitly zero, force remote verification so that
+    // session_duration_minutes and session_custom_claims are reliably applied.
+    if (params.max_token_age_seconds === 0) {
+      return this.authenticate({
+        session_jwt: params.session_jwt,
+        authorization_check: params.authorization_check,
+        session_duration_minutes: params.session_duration_minutes,
+        session_custom_claims: params.session_custom_claims,
+      });
+    }
+
     try {
       const session = await this.authenticateJwtLocal(params);
       return {
@@ -1174,6 +1204,8 @@ export class Sessions {
       return this.authenticate({
         session_jwt: params.session_jwt,
         authorization_check: params.authorization_check,
+        session_duration_minutes: params.session_duration_minutes,
+        session_custom_claims: params.session_custom_claims,
       });
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stytch",
-  "version": "14.0.0",
+  "version": "14.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "stytch",
-      "version": "14.0.0",
+      "version": "14.0.1",
       "license": "MIT",
       "dependencies": {
         "jose": "^5.10.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stytch",
-  "version": "14.0.1",
+  "version": "14.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "stytch",
-      "version": "14.0.1",
+      "version": "14.1.0",
       "license": "MIT",
       "dependencies": {
         "jose": "^5.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stytch",
-  "version": "14.0.0",
+  "version": "14.0.1",
   "description": "A wrapper for the Stytch API",
   "types": "./types/lib/index.d.ts",
   "main": "./dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stytch",
-  "version": "14.0.1",
+  "version": "14.1.0",
   "description": "A wrapper for the Stytch API",
   "types": "./types/lib/index.d.ts",
   "main": "./dist/index.js",

--- a/test/b2b/sessions.test.ts
+++ b/test/b2b/sessions.test.ts
@@ -261,6 +261,101 @@ describe("sessions.authenticateJwt", () => {
       },
     });
   });
+
+  test("forwards session_duration_minutes and session_custom_claims on remote fallback", () => {
+    mockRequest((req) => {
+      expect(req).toEqual({
+        method: "POST",
+        path: "/v1/b2b/sessions/authenticate",
+        data: {
+          session_jwt: "stale_jwt",
+          session_duration_minutes: 60,
+          session_custom_claims: { key: "value" },
+        },
+      });
+
+      const data = {
+        request_id: "request-id-test-a8876db0-601a-4251-94bd-79dafe63f4dc",
+        session_jwt: "fresh_jwt",
+        member_session: {
+          expires_at: "2021-08-30T18:16:53.370383Z",
+          last_accessed_at: "2021-08-30T17:16:53.370383Z",
+          member_session_id:
+            "session-test-eb94233f-8800-4ebd-8645-51dc15f9d028",
+          started_at: "2021-08-28T00:41:58.935673870Z",
+          member_id: "member-test-e3795c81-f849-4167-bfda-e4a6e9c280fd",
+        },
+        status_code: 200,
+      };
+      return { status: 200, data };
+    });
+    const sessions = new Sessions(
+      MOCK_FETCH_CONFIG,
+      jwtConfig(),
+      mockPolicyCache
+    );
+
+    return expect(
+      sessions.authenticateJwt({
+        session_jwt: "stale_jwt",
+        session_duration_minutes: 60,
+        session_custom_claims: { key: "value" },
+      })
+    ).resolves.toMatchObject({
+      session_jwt: "fresh_jwt",
+      member_session: {
+        member_id: "member-test-e3795c81-f849-4167-bfda-e4a6e9c280fd",
+      },
+    });
+  });
+
+  test("max_token_age_seconds of zero forces remote verification", () => {
+    mockRequest((req) => {
+      expect(req).toEqual({
+        method: "POST",
+        path: "/v1/b2b/sessions/authenticate",
+        data: {
+          session_jwt: "valid_jwt",
+          session_duration_minutes: 60,
+          session_custom_claims: { key: "value" },
+        },
+      });
+
+      const data = {
+        request_id: "request-id-test-a8876db0-601a-4251-94bd-79dafe63f4dc",
+        session_jwt: "fresh_jwt",
+        member_session: {
+          expires_at: "2021-08-30T18:16:53.370383Z",
+          last_accessed_at: "2021-08-30T17:16:53.370383Z",
+          member_session_id:
+            "session-test-eb94233f-8800-4ebd-8645-51dc15f9d028",
+          started_at: "2021-08-28T00:41:58.935673870Z",
+          member_id: "member-test-e3795c81-f849-4167-bfda-e4a6e9c280fd",
+        },
+        status_code: 200,
+      };
+      return { status: 200, data };
+    });
+    const sessions = new Sessions(
+      MOCK_FETCH_CONFIG,
+      jwtConfig(),
+      mockPolicyCache
+    );
+
+    return expect(
+      sessions.authenticateJwt({
+        session_jwt: "valid_jwt",
+        max_token_age_seconds: 0,
+        session_duration_minutes: 60,
+        session_custom_claims: { key: "value" },
+      })
+    ).resolves.toMatchObject({
+      session_jwt: "fresh_jwt",
+      member_session: {
+        member_id: "member-test-e3795c81-f849-4167-bfda-e4a6e9c280fd",
+      },
+    });
+  });
 });
 
 /** Format the UTC timestamp truncated to second precision. */

--- a/test/b2c/sessions.test.ts
+++ b/test/b2c/sessions.test.ts
@@ -201,6 +201,99 @@ describe("sessions.authenticateJwt", () => {
       },
     });
   });
+
+  test("forwards session_duration_minutes and session_custom_claims on remote fallback", () => {
+    mockRequest((req) => {
+      expect(req).toEqual({
+        method: "POST",
+        path: "/v1/sessions/authenticate",
+        data: {
+          session_jwt: "stale_jwt",
+          session_duration_minutes: 60,
+          session_custom_claims: { key: "value" },
+        },
+      });
+
+      const data = {
+        request_id: "request-id-test-a8876db0-601a-4251-94bd-79dafe63f4dc",
+        session_jwt: "fresh_jwt",
+        session: {
+          attributes: null,
+          expires_at: "2021-08-30T18:16:53.370383Z",
+          last_accessed_at: "2021-08-30T17:16:53.370383Z",
+          session_id: "session-test-eb94233f-8800-4ebd-8645-51dc15f9d028",
+          started_at: "2021-08-28T00:41:58.935673870Z",
+          user_id: "user-test-e3795c81-f849-4167-bfda-e4a6e9c280fd",
+        },
+        status_code: 200,
+      };
+      return { status: 200, data };
+    });
+    const sessions = new Sessions(
+      MOCK_FETCH_CONFIG,
+      jwtConfig("project-test-00000000-0000-4000-8000-000000000000")
+    );
+
+    return expect(
+      sessions.authenticateJwt({
+        session_jwt: "stale_jwt",
+        session_duration_minutes: 60,
+        session_custom_claims: { key: "value" },
+      })
+    ).resolves.toMatchObject({
+      session_jwt: "fresh_jwt",
+      session: {
+        user_id: "user-test-e3795c81-f849-4167-bfda-e4a6e9c280fd",
+      },
+    });
+  });
+
+  test("max_token_age_seconds of zero forces remote verification", () => {
+    mockRequest((req) => {
+      expect(req).toEqual({
+        method: "POST",
+        path: "/v1/sessions/authenticate",
+        data: {
+          session_jwt: "valid_jwt",
+          session_duration_minutes: 60,
+          session_custom_claims: { key: "value" },
+        },
+      });
+
+      const data = {
+        request_id: "request-id-test-a8876db0-601a-4251-94bd-79dafe63f4dc",
+        session_jwt: "fresh_jwt",
+        session: {
+          attributes: null,
+          expires_at: "2021-08-30T18:16:53.370383Z",
+          last_accessed_at: "2021-08-30T17:16:53.370383Z",
+          session_id: "session-test-eb94233f-8800-4ebd-8645-51dc15f9d028",
+          started_at: "2021-08-28T00:41:58.935673870Z",
+          user_id: "user-test-e3795c81-f849-4167-bfda-e4a6e9c280fd",
+        },
+        status_code: 200,
+      };
+      return { status: 200, data };
+    });
+    const sessions = new Sessions(
+      MOCK_FETCH_CONFIG,
+      jwtConfig("project-test-00000000-0000-4000-8000-000000000000")
+    );
+
+    return expect(
+      sessions.authenticateJwt({
+        session_jwt: "valid_jwt",
+        max_token_age_seconds: 0,
+        session_duration_minutes: 60,
+        session_custom_claims: { key: "value" },
+      })
+    ).resolves.toMatchObject({
+      session_jwt: "fresh_jwt",
+      session: {
+        user_id: "user-test-e3795c81-f849-4167-bfda-e4a6e9c280fd",
+      },
+    });
+  });
 });
 
 /** Format the UTC timestamp truncated to second precision. */

--- a/types/lib/b2b/sessions.d.ts
+++ b/types/lib/b2b/sessions.d.ts
@@ -545,6 +545,18 @@ export interface B2BSessionsAuthenticateJwtRequest {
      * If explicitly set to zero, all tokens will be considered too old, even if they are otherwise valid.
      */
     max_token_age_seconds?: number;
+    /**
+     * Set the session lifetime to be this many minutes from now. This is only applied when the session is
+     * authenticated remotely against the Stytch API (i.e. when the JWT cannot be verified locally, or when
+     * remote verification is forced by setting `max_token_age_seconds` to zero). Local verification does not
+     * extend the session, so a JWT that verifies locally will ignore this value.
+     */
+    session_duration_minutes?: number;
+    /**
+     * Add a custom claims map to the Session being authenticated. As with `session_duration_minutes`, this is
+     * only applied when the session is authenticated remotely against the Stytch API.
+     */
+    session_custom_claims?: Record<string, any>;
 }
 export interface B2BSessionsAuthenticateJwtLocalRequest {
     /**
@@ -743,6 +755,11 @@ export declare class Sessions {
      *
      * To force remote validation for all tokens, set max_token_age_seconds to zero or use the
      * authenticate method instead.
+     *
+     * The session_duration_minutes and session_custom_claims parameters are only applied when the
+     * session is authenticated remotely against the Stytch API. Local verification does not extend
+     * the session, so a JWT that verifies locally will ignore these values. To guarantee they are
+     * applied, set max_token_age_seconds to zero to force remote verification.
      */
     authenticateJwt(params: B2BSessionsAuthenticateJwtRequest): Promise<{
         member_session: MemberSession;

--- a/types/lib/b2c/sessions.d.ts
+++ b/types/lib/b2c/sessions.d.ts
@@ -697,6 +697,18 @@ export interface SessionsAuthenticateJwtRequest {
      * If explicitly set to zero, all tokens will be considered too old, even if they are otherwise valid.
      */
     max_token_age_seconds?: number;
+    /**
+     * Set the session lifetime to be this many minutes from now. This is only applied when the session is
+     * authenticated remotely against the Stytch API (i.e. when the JWT cannot be verified locally, or when
+     * remote verification is forced by setting `max_token_age_seconds` to zero). Local verification does not
+     * extend the session, so a JWT that verifies locally will ignore this value.
+     */
+    session_duration_minutes?: number;
+    /**
+     * Add a custom claims map to the Session being authenticated. As with `session_duration_minutes`, this is
+     * only applied when the session is authenticated remotely against the Stytch API.
+     */
+    session_custom_claims?: Record<string, any>;
 }
 export interface SessionsAuthenticateJwtLocalRequest {
     /**
@@ -837,6 +849,11 @@ export declare class Sessions {
      *
      * To force remote validation for all tokens, set max_token_age_seconds to zero or use the
      * authenticate method instead.
+     *
+     * The session_duration_minutes and session_custom_claims parameters are only applied when the
+     * session is authenticated remotely against the Stytch API. Local verification does not extend
+     * the session, so a JWT that verifies locally will ignore these values. To guarantee they are
+     * applied, set max_token_age_seconds to zero to force remote verification.
      */
     authenticateJwt(params: SessionsAuthenticateJwtRequest): Promise<{
         session: Session;


### PR DESCRIPTION
# Description

Adds support for the `session_duration_minutes` and `session_custom_claims` params in `authenticateJwt()` for both B2B and Consumer

This method is manually generated (i.e. not managed by codegen), so I believe this doesn't require changes elsewhere. I ran `npm run build`.

The logic mirrors the Ruby and Go SDK's logic which currently supports `session_duration_minutes` as a param: https://github.com/stytchauth/stytch-ruby/blob/32cf1771b62e0b8ac320f6d1d955cc061fd2c888/lib/stytch/b2b_sessions.rb#L628-L678

https://github.com/stytchauth/stytch-go/blob/87c4a9068c1e2dad24acbc151f15b6eb642f86a3/stytch/b2b/sessions.go#L446-L448

* It'll essentially silently ignore `session_duration_minutes` if the JWT is verified locally
* Remote JWT validation can now be forced by passing in `max_token_age_seconds = 0` 

# Motivation

Customer request from the community Slack: https://app.plain.com/workspace/w_01HAQ5N757DAG0R7JTXZ4MQYKY/thread/th_01KTS9YSFQJ7KRDEXBJ3NQVA9M/

Our API docs say you can pass in `session_duration_minutes` to extend a Session's lifetime (when the auth doesn't happen locally): https://stytch.com/docs/api-reference/b2b/api/sessions/authenticate-jwt

but from what I found, only some of our backend SDKs currently support this param today, like Ruby and Go:

Ruby:
https://github.com/stytchauth/stytch-ruby/blob/32cf1771b62e0b8ac320f6d1d955cc061fd2c888/lib/stytch/b2b_sessions.rb#L628-L678

Golang:
https://github.com/stytchauth/stytch-go/blob/87c4a9068c1e2dad24acbc151f15b6eb642f86a3/stytch/b2b/sessions.go#L435-L459

but not Python and Java:

Python:
https://github.com/stytchauth/stytch-python/blob/6987801e7eb03b0c6b34dc46f042e5d532e7299a/stytch/b2b/api/sessions.py#L806-L856

Java:
https://github.com/stytchauth/stytch-java/blob/f85a264f20b2a50132acefbbd27d99c9bd17865c/stytch/src/main/kotlin/com/stytch/java/b2b/api/sessions/Sessions.kt#L458-L471

Action item for the future would be to add this to the rest of the backend SDKs for parity

# Testing

- [x] Added tests