### PR TITLE
chore: migrate GitHub runners to ubuntu-latest-public

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build-and-publish:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-public
     name: Build and publish stytch package to NPM
     permissions:
       id-token: write # Required for OIDC

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   check-links:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-public
     name: Check links in README.md
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   eslint:
     name: ESLint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-public
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v2
@@ -18,7 +18,7 @@ jobs:
 
   prettier:
     name: Prettier
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-public
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   unit-test:
     name: Run Unit Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-public
     strategy:
       matrix:
         version: [18, 20, 22]
@@ -21,7 +21,7 @@ jobs:
 
   integration-test:
     name: Run Integration Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-public
     strategy:
       matrix:
         version: [18, 20, 22]
@@ -44,7 +44,7 @@ jobs:
 
   build:
     name: Check Packaged Files
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-public
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v2


### PR DESCRIPTION
Migrates all `ubuntu-latest` runner references to `ubuntu-latest-public` (org-scoped GitHub-hosted runner group).